### PR TITLE
Fix typo in BidsValidator plugin

### DIFF
--- a/snakebids/plugins/validator.py
+++ b/snakebids/plugins/validator.py
@@ -56,7 +56,7 @@ class BidsValidator:
             temp.flush()
             try:
                 subprocess.check_call(
-                    ["bids-validator", app.config["bids_dirs"], "-c", temp.name]
+                    ["bids-validator", app.config["bids_dir"], "-c", temp.name]
                 )
 
                 # If successfully bids-validation performed

--- a/snakebids/tests/test_validate_plugin.py
+++ b/snakebids/tests/test_validate_plugin.py
@@ -35,7 +35,7 @@ class TestBidsValidator:
         # Test successful validation
         mocker.patch("subprocess.check_call", return_value=0)
 
-        app.config["bids_dirs"] = "path/to/bids/dir"
+        app.config["bids_dir"] = "path/to/bids/dir"
         app.config["plugins.validator.skip"] = False
 
         validator = BidsValidator()
@@ -48,7 +48,7 @@ class TestBidsValidator:
         # Test fall back to Pybids validation
         mocker.patch("subprocess.check_call", side_effect=FileNotFoundError)
 
-        app.config["bids_dirs"] = "path/to/bids/dir"
+        app.config["bids_dir"] = "path/to/bids/dir"
         app.config["plugins.validator.skip"] = False
 
         validator = BidsValidator()
@@ -68,7 +68,7 @@ class TestBidsValidator:
             "subprocess.check_call", side_effect=subprocess.CalledProcessError(1, "")
         )
 
-        app.config["bids_dirs"] = "path/to/bids/dir"
+        app.config["bids_dir"] = "path/to/bids/dir"
         app.config["plugins.validator.skip"] = False
 
         # Check error raised
@@ -85,7 +85,7 @@ class TestBidsValidator:
             "subprocess.check_call", side_effect=subprocess.CalledProcessError(1, "")
         )
 
-        app.config["bids_dirs"] = "path/to/bids/dir"
+        app.config["bids_dir"] = "path/to/bids/dir"
         app.config["plugins.validator.skip"] = False
 
         # Check if error is skipped on invalid


### PR DESCRIPTION
It had `bids_dirs` where it should have been `bids_dir` to match previous convention and the template app. I didn't add any tests for this (previous tests didn't catch it because the typo was throughout all the tests), but upcoming E2E tests in #336 will be able to catch the problem (that's where I found it in the first place)