### PR TITLE
Add tests of pypi installation in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,26 +3,18 @@ name: Weekly testing and recalibration of test timings
 on:
   schedule:
     - cron: "5 3 * * 2"
+  push:
+    branches:
+      - '*'
+      - '!push-action/*'
+  pull_request:
+    branches:
+      - '*'
+      - '!push-action/*'
 
 jobs:
-  build-cache-env:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-    steps:
-      - uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.3.3
-        id: setup
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: setup docker
-        uses: ./.github/actions/build-test-container
-        with:
-          python-version: ${{ steps.setup.outputs.python-version }}
-
   calibrate-timings:
     runs-on: ubuntu-latest
-    needs: ["build-cache-env"]
     permissions:
       pull-requests: write
 
@@ -76,3 +68,63 @@ jobs:
           body: |
             The number of tests has changed since the last generated test-timings
             file. This PR contains an automatically regenerated file.
+
+  build-cache-env:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@feat/flexible-installs
+        id: setup
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache-key: pypi
+          sparse-checkout: |
+            snakebids/tests
+            pyproject.toml
+            poetry.lock
+          install-deps-only: dev
+          install-library: snakebids
+
+      - name: build docker test container
+        uses: ./.github/actions/build-test-container
+        with:
+          python-version: ${{ steps.setup.outputs.python-version }}
+          load: true
+
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [ 'build-cache-env'  ]
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        split: ['1', '2', '3', '4', '5']
+      fail-fast: false
+    steps:
+      - uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@feat/flexible-installs
+        id: setup
+        with:
+          python-version: ${{ matrix.python-version }}
+          sparse-checkout: |
+            snakebids/tests
+            pyproject.toml
+            poetry.lock
+          cache-key: pypi
+          install-deps-only: dev
+          install-library: snakebids
+
+      - name: build docker test container
+        uses: ./.github/actions/build-test-container
+        with:
+          python-version: ${{ steps.setup.outputs.python-version }}
+          load: true
+
+      - name: Test with pytest
+        env:
+          HYPOTHESIS_PROFILE: pr
+        run: >-
+          poetry run pytest -n auto --splits 5 --group ${{ matrix.split }}
+          --doctest-modules --ignore=docs
+          --ignore=snakebids/project_template --benchmark-disable

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,7 +105,7 @@ jobs:
         id: setup
         with:
           python-version: ${{ matrix.python-version }}
-          cache-key: pypi
+          cache-key: nightly
           install-deps-only: dev
           install-library: false
       - name: install lib

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,6 +84,7 @@ jobs:
             snakebids/tests
             pyproject.toml
             poetry.lock
+            .github
           install-deps-only: dev
           install-library: snakebids
 
@@ -111,6 +112,7 @@ jobs:
             snakebids/tests
             pyproject.toml
             poetry.lock
+            .github
           cache-key: pypi
           install-deps-only: dev
           install-library: snakebids

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,7 +87,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [ 'build-cache-env'  ]
+    needs: [ 'build-cache-env' ]
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
@@ -101,6 +101,7 @@ jobs:
           cache-key: nightly
           install-deps-only: dev
           install-library: false
+
       - name: install lib
         run: poetry run pip install .
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,20 +3,13 @@ name: Weekly testing and recalibration of test timings
 on:
   schedule:
     - cron: "5 3 * * 2"
-  push:
-    branches:
-      - '*'
-      - '!push-action/*'
-  pull_request:
-    branches:
-      - '*'
-      - '!push-action/*'
 
 jobs:
   calibrate-timings:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write
 
     steps:
       - name: install
@@ -75,7 +68,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@feat/flexible-installs
+      - uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.3.4
         id: setup
         with:
           python-version: ${{ matrix.python-version }}
@@ -101,7 +94,7 @@ jobs:
         split: ['1', '2', '3', '4', '5']
       fail-fast: false
     steps:
-      - uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@feat/flexible-installs
+      - uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.3.4
         id: setup
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,14 +80,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache-key: pypi
-          sparse-checkout: |
-            snakebids/tests
-            pyproject.toml
-            poetry.lock
-            .github
-            containers
           install-deps-only: dev
-          install-library: snakebids
+          install-library: false
 
       - name: build docker test container
         uses: ./.github/actions/build-test-container
@@ -95,6 +89,8 @@ jobs:
           python-version: ${{ steps.setup.outputs.python-version }}
           load: true
 
+      - name: install lib
+        run: poetry run pip install .
 
   test:
     runs-on: ubuntu-latest
@@ -109,15 +105,11 @@ jobs:
         id: setup
         with:
           python-version: ${{ matrix.python-version }}
-          sparse-checkout: |
-            snakebids/tests
-            pyproject.toml
-            poetry.lock
-            .github
-            containers
           cache-key: pypi
           install-deps-only: dev
-          install-library: snakebids
+          install-library: false
+      - name: install lib
+        run: poetry run pip install .
 
       - name: build docker test container
         uses: ./.github/actions/build-test-container

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,6 +85,7 @@ jobs:
             pyproject.toml
             poetry.lock
             .github
+            containers
           install-deps-only: dev
           install-library: snakebids
 
@@ -113,6 +114,7 @@ jobs:
             pyproject.toml
             poetry.lock
             .github
+            containers
           cache-key: pypi
           install-deps-only: dev
           install-library: snakebids


### PR DESCRIPTION
Rather than just run the usual test workflow with the pinned dependencies, I thought it would be more useful to test installing the project from pypi with the latest of all dependencies. So this contains the attempt to do that. The code depends on a custom branch in khanlab/actions, but if everything works here, I'll make a merge of that branch