### PR TITLE
Restrict pulp version in template app

### DIFF
--- a/snakebids/project_template/{% if build_system != 'poetry' %}pyproject.toml{% endif %}.jinja
+++ b/snakebids/project_template/{% if build_system != 'poetry' %}pyproject.toml{% endif %}.jinja
@@ -30,6 +30,11 @@ requires-python = "{{ python_version }}"
 dependencies = [
     "snakemake >= {{ snakemake_version }},<8",
     "snakebids >= {{ snakebids_version }}",
+    {#- newer pulps are incompatible with old snakemakes, and we need to support
+    old snakemakes for python versions <3.11. So cap pulp to the last working
+    version
+    #}
+    "pulp < 2.8.0",
 ]
 
 [project.scripts]

--- a/snakebids/project_template/{% if build_system == 'poetry' %}pyproject.toml{% endif %}.jinja
+++ b/snakebids/project_template/{% if build_system == 'poetry' %}pyproject.toml{% endif %}.jinja
@@ -24,6 +24,11 @@ classifiers = [
 python = "{{ python_version }}"
 snakemake = ">={{ snakemake_version }},<8"
 snakebids = ">={{ snakebids_version }}"
+{#- newer pulps are incompatible with old snakemakes, and we need to support
+old snakemakes for python versions <3.11. So cap pulp to the last working
+version
+#}
+pulp = "<2.8.0"
 pandas = [
     { version = "<=2.0.3", python = "<3.9" },
     { version = ">=2.1.1", python = ">=3.12" },


### PR DESCRIPTION
The latest versions of pulp dropped a deprecated api snakemake dependended on. Newer versions of snakemake will address this, but older versions don't have an upper pin on pulp.

We cannot lower-pin the snakemake version, as we need older snakemakes to maintain support for python < 3.11.

This is not an ideal situation, as if we want the template app to work on all python versions supported by snakebids, and if we want to support all actively maintained pythons, we won't be able to drop this pin on pulp until python 3.10 is dropped, which won't be for a few years.

Probably the best is to wait until either 3.8 or 3.9 is EOL, then change the template app to require python >= 3.11 and snakemake >= 8.2. By that point, python 3.13 or 3.14 will be released, so people should have been able to get their default python version up to 3.11 or higher.