### PR TITLE
Exclude `run` from test strategy

### DIFF
--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -710,8 +710,9 @@ class TestFilterMethods:
             name="template",
             min_entities=2,
             max_entities=2,
-            # Again, extension doesn't work with regex
-            blacklist_entities={"extension"},
+            # Again, extension doesn't work with regex. run causes problem with
+            # numeral strings
+            blacklist_entities={"extension", "run"},
             min_values=2,
             restrict_patterns=True,
             unique=True,


### PR DESCRIPTION
This fixes the failing test on main.

The pybids internal formatting of values as integers caused problems