### PR TITLE
Update updated spec name, declare spec for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           poetry run poe update-bids
           git diff --quiet || (
-            git status
+            git diff
             echo 'bids specs out of date, run `poetry run poe update-bids`'
             exit 1
           )

--- a/scripts/update_bids.py
+++ b/scripts/update_bids.py
@@ -133,7 +133,7 @@ def get_latest(versions: Iterable[BidsPathSpecFile]) -> tuple[str, BidsPathSpecF
 
 def main():
     """update_bids entrypoint."""
-    all_specs = list(get_specs())
+    all_specs = sorted(get_specs(), key=lambda o: o["version"])
     latest_version, latest_spec = get_latest(all_specs)
     generate_stub(
         specs,

--- a/snakebids/paths/_config.py
+++ b/snakebids/paths/_config.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 #       poetry run poe update-bids
 #
 
-VALID_SPECS: TypeAlias = Literal["v0_10_1", "v0_0_0", "latest"]
+VALID_SPECS: TypeAlias = Literal["v0_11_0", "v0_0_0", "latest"]
 # </AUTOUPDATE>
 
 __all__ = ["set_bids_spec"]

--- a/snakebids/paths/_config.py
+++ b/snakebids/paths/_config.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 #       poetry run poe update-bids
 #
 
-VALID_SPECS: TypeAlias = Literal["v0_11_0", "v0_0_0", "latest"]
+VALID_SPECS: TypeAlias = Literal["v0_0_0", "v0_11_0", "latest"]
 # </AUTOUPDATE>
 
 __all__ = ["set_bids_spec"]

--- a/snakebids/paths/resources/spec.0.11.0.yaml
+++ b/snakebids/paths/resources/spec.0.11.0.yaml
@@ -1,11 +1,11 @@
-version: "v0.10.1"
+version: "v0.11.0"
 description: |
   Spec corresponding to `BIDS v1.9.0`_.
 
   Significantly expanded from the v0.0.0 spec, now including long names for
-  every relevant entity. In addition to the spec, it includes `from` and `to`
-  entities intended for transformations. Unknown entities are placed just before
-  desc, so that the description entity is always last.
+  every relevant entity. In addition to the official spec, it includes `from`
+  and `to` entities intended for transformations. Unknown entities are placed
+  just before desc, so that the description entity is always last.
 
   .. _BIDS v1.9.0: https://bids-specification.readthedocs.io/en/v1.9.0/
 

--- a/snakebids/paths/specs.py
+++ b/snakebids/paths/specs.py
@@ -15,8 +15,8 @@ from snakebids.paths._utils import BidsPathSpec, find_entity, get_spec_path, loa
 #
 if not TYPE_CHECKING:
     __all__ = [  # noqa:F822
-        "v0_11_0",
         "v0_0_0",
+        "v0_11_0",
         "latest",
         "LATEST",
     ]
@@ -25,7 +25,7 @@ if not TYPE_CHECKING:
         return __all__
 
 
-_SPECS = ["v0_11_0", "v0_0_0"]
+_SPECS = ["v0_0_0", "v0_11_0"]
 # LATEST = "v0_11_0"
 # </AUTOUPDATE>
 

--- a/snakebids/paths/specs.py
+++ b/snakebids/paths/specs.py
@@ -15,7 +15,7 @@ from snakebids.paths._utils import BidsPathSpec, find_entity, get_spec_path, loa
 #
 if not TYPE_CHECKING:
     __all__ = [  # noqa:F822
-        "v0_10_1",
+        "v0_11_0",
         "v0_0_0",
         "latest",
         "LATEST",
@@ -25,8 +25,8 @@ if not TYPE_CHECKING:
         return __all__
 
 
-_SPECS = ["v0_10_1", "v0_0_0"]
-# LATEST = "v0_10_1"
+_SPECS = ["v0_11_0", "v0_0_0"]
+# LATEST = "v0_11_0"
 # </AUTOUPDATE>
 
 # To automatically use latest spec as "LATEST", remove this line and uncomment the

--- a/snakebids/paths/specs.pyi
+++ b/snakebids/paths/specs.pyi
@@ -7,13 +7,13 @@ from ._utils import BidsPathSpec
 
 LATEST: str
 
-def v0_10_1(subject_dir: bool = True, session_dir: bool = True) -> BidsPathSpec:
+def v0_11_0(subject_dir: bool = True, session_dir: bool = True) -> BidsPathSpec:
     """Spec corresponding to `BIDS v1.9.0`_.
 
     Significantly expanded from the v0.0.0 spec, now including long names for every
-    relevant entity. In addition to the spec, it includes `from` and `to` entities
-    intended for transformations. Unknown entities are placed just before desc, so that
-    the description entity is always last.
+    relevant entity. In addition to the official spec, it includes `from` and `to`
+    entities intended for transformations. Unknown entities are placed just before desc,
+    so that the description entity is always last.
 
     .. _BIDS v1.9.0: https://bids-specification.readthedocs.io/en/v1.9.0/
 
@@ -73,9 +73,9 @@ def latest(subject_dir: bool = True, session_dir: bool = True) -> BidsPathSpec:
     """Spec corresponding to `BIDS v1.9.0`_.
 
     Significantly expanded from the v0.0.0 spec, now including long names for every
-    relevant entity. In addition to the spec, it includes `from` and `to` entities
-    intended for transformations. Unknown entities are placed just before desc, so that
-    the description entity is always last.
+    relevant entity. In addition to the official spec, it includes `from` and `to`
+    entities intended for transformations. Unknown entities are placed just before desc,
+    so that the description entity is always last.
 
     .. _BIDS v1.9.0: https://bids-specification.readthedocs.io/en/v1.9.0/
 

--- a/snakebids/paths/specs.pyi
+++ b/snakebids/paths/specs.pyi
@@ -7,6 +7,34 @@ from ._utils import BidsPathSpec
 
 LATEST: str
 
+def v0_0_0(subject_dir: bool = True, session_dir: bool = True) -> BidsPathSpec:
+    """Get the v0.0.0 BidsPathSpec.
+
+    This spec alone equips :func:`~snakebids.bids` with 2 extra arguments:
+    ``include_subject_dir`` and ``include_session_dir``. These default to ``True``, but
+    if set ``False``, remove the subject and session dirs respectively from the output
+    path. For future specs, this behaviour should be achieved by modifying the spec and
+    generating a new :func:`~snakebids.bids` function
+
+    Formatted as::
+
+        sub-{subject}/ses-{session}/{datatype}/{prefix}_sub-{subject}_ses-{session}_
+        task-{task}_acq-{acq}_ce-{ce}_rec-{rec}_dir-{dir}_run-{run}_mod-{mod}_
+        echo-{echo}_hemi-{hemi}_space-{space}_res-{res}_den-{den}_label-{label}_
+        desc-{desc}_..._{suffix}{extension}
+
+
+    Parameters
+    ----------
+    subject_dir
+        If False, downstream path generator will not include the subject dir
+        `sub-{subject}/*`
+    session_dir : bool, optional
+        If False, downstream path generator will not include the session dir
+        `*/ses-{session}/*`
+    """
+    ...
+
 def v0_11_0(subject_dir: bool = True, session_dir: bool = True) -> BidsPathSpec:
     """Spec corresponding to `BIDS v1.9.0`_.
 
@@ -28,34 +56,6 @@ def v0_11_0(subject_dir: bool = True, session_dir: bool = True) -> BidsPathSpec:
         den-{density}_roi-{roi}_from-{from}_to-{to}_split-{split}_
         recording-{recording}_chunk-{chunk}_model-{model}_subset-{subset}_
         label-{label}_..._desc-{description}_{suffix}{extension}
-
-
-    Parameters
-    ----------
-    subject_dir
-        If False, downstream path generator will not include the subject dir
-        `sub-{subject}/*`
-    session_dir : bool, optional
-        If False, downstream path generator will not include the session dir
-        `*/ses-{session}/*`
-    """
-    ...
-
-def v0_0_0(subject_dir: bool = True, session_dir: bool = True) -> BidsPathSpec:
-    """Get the v0.0.0 BidsPathSpec.
-
-    This spec alone equips :func:`~snakebids.bids` with 2 extra arguments:
-    ``include_subject_dir`` and ``include_session_dir``. These default to ``True``, but
-    if set ``False``, remove the subject and session dirs respectively from the output
-    path. For future specs, this behaviour should be achieved by modifying the spec and
-    generating a new :func:`~snakebids.bids` function
-
-    Formatted as::
-
-        sub-{subject}/ses-{session}/{datatype}/{prefix}_sub-{subject}_ses-{session}_
-        task-{task}_acq-{acq}_ce-{ce}_rec-{rec}_dir-{dir}_run-{run}_mod-{mod}_
-        echo-{echo}_hemi-{hemi}_space-{space}_res-{res}_den-{den}_label-{label}_
-        desc-{desc}_..._{suffix}{extension}
 
 
     Parameters

--- a/snakebids/tests/conftest.py
+++ b/snakebids/tests/conftest.py
@@ -10,7 +10,7 @@ from hypothesis import database, settings
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 import snakebids.paths.resources as specs
-from snakebids import resources
+from snakebids import resources, set_bids_spec
 
 ## Hypothesis profiles
 
@@ -27,9 +27,10 @@ settings.register_profile("dev", database=database.InMemoryExampleDatabase())
 
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))
 
+set_bids_spec("v0_0_0")
+
+
 # Fixtures
-
-
 @pytest.fixture
 def fakefs(
     request: pytest.FixtureRequest,

--- a/snakebids/tests/test_paths/test_bids.py
+++ b/snakebids/tests/test_paths/test_bids.py
@@ -302,7 +302,7 @@ def make_bids_testsuite(spec: BidsPathSpec):
 
 TestV0_0_0 = make_bids_testsuite(specs.v0_0_0())
 
-TestV0_10_1 = make_bids_testsuite(specs.v0_10_1())
+TestV0_10_1 = make_bids_testsuite(specs.v0_11_0())
 
 
 def test_benchmark_bids(benchmark: Benchmark):

--- a/snakebids/tests/test_paths/test_specs.py
+++ b/snakebids/tests/test_paths/test_specs.py
@@ -53,14 +53,14 @@ def test_session_dir_can_be_excluded():
 def test_spec_can_be_set_with_str():
     set_bids_spec("v0_0_0")
     assert bids(acquisition="foo") == "acquisition-foo"
-    set_bids_spec("v0_10_1")
+    set_bids_spec("v0_11_0")
     assert bids(acquisition="foo") == "acq-foo"
 
 
 def test_spec_can_be_set_with_obj():
     set_bids_spec(specs.v0_0_0())
     assert bids(acquisition="foo") == "acquisition-foo"
-    set_bids_spec(specs.v0_10_1())
+    set_bids_spec(specs.v0_11_0())
     assert bids(acquisition="foo") == "acq-foo"
 
 

--- a/snakebids/tests/test_yaml.py
+++ b/snakebids/tests/test_yaml.py
@@ -16,7 +16,7 @@ import snakebids.io.config as configio
 import snakebids.io.yaml as yamlio
 from snakebids.tests.helpers import allow_function_scoped
 
-YAML_SAFE_CHARS = st.characters(blacklist_characters=["\x85"])
+YAML_SAFE_CHARS = st.characters(blacklist_characters=["\\"], blacklist_categories=["C"])
 
 
 @given(path=st.text(YAML_SAFE_CHARS, min_size=1).map(Path))


### PR DESCRIPTION
Just a small maintenance PR before the next release. This updates the name of the 0_10_1 spec to 0_11_0 to reflect the fact that it will be released in v0.11.0. It also declares a spec in `conftest.py` to silence the numerous warnings now being thrown for the current lack of declaration.