### PR TITLE
Default to case-insensitive search for regex

### DIFF
--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -505,6 +505,17 @@ class TestFilterMethods:
     @example(
         component=BidsComponent(
             name="template",
+            path="sub-{subject}/ses-{session}/sub-{subject}_ses-{session}",
+            zip_lists={
+                "session": ["0A", "0a"],
+                "subject": ["0", "00"],
+            },
+        ),
+        data=mock_data(["0a"]),
+    )
+    @example(
+        component=BidsComponent(
+            name="template",
             path="sub-{subject}/sub-{subject}_mt-{mt}",
             zip_lists={
                 "subject": ["0", "00"],


### PR DESCRIPTION
Discovered via testing in another branch that pybid's regex search defaults to case-insensitive, which I find unexpected. I'd prefer it be made case-sensitive, especially for snakebids where filters will often be saved into configuration files and should be explicit. This would also simplify our test suite, as I won't have to special case the previous failure.

This uses in-pattern regex groups to disable the flag. In the future, this same technique could be used to enable more customization of flags.

Also cleans up the logic in the filter parsing functions
