### PR TITLE
Expand paths unaltered when comp has no wcards

### DIFF
--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -394,17 +394,20 @@ class BidsPartialComponent:
             return list(itx.always_iterable(item))
 
         allow_missing_seq = sequencify(allow_missing)
-        inner_expand = list(
-            # order preserving deduplication
-            dict.fromkeys(
-                sn_expand(
-                    list(itx.always_iterable(paths)),
-                    zip,
-                    allow_missing=True if wildcards else allow_missing_seq,
-                    **self.zip_lists,
+        if self.zip_lists:
+            inner_expand = list(
+                # order preserving deduplication
+                dict.fromkeys(
+                    sn_expand(
+                        list(itx.always_iterable(paths)),
+                        zip,
+                        allow_missing=True if wildcards else allow_missing_seq,
+                        **self.zip_lists,
+                    )
                 )
             )
-        )
+        else:
+            inner_expand = list(itx.always_iterable(paths))
         if not wildcards:
             return inner_expand
 

--- a/snakebids/tests/test_admin.py
+++ b/snakebids/tests/test_admin.py
@@ -133,7 +133,9 @@ class TestCreateCommand:
 
     @given(
         name=st.from_regex(r"^[a-zA-Z_][a-zA-Z_0-9]*$"),
-        version=st.text(st.characters(blacklist_characters=["@", ";", "["]))
+        version=st.text(st.characters(blacklist_characters=["@", ";", "["])).filter(
+            lambda s: not s.startswith("-")
+        )
         | st.none(),
     )
     @allow_function_scoped

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -340,6 +340,16 @@ class TestExpandables:
         for path, entity_vals in zip(paths, zip(*component.zip_lists.values())):
             assert bids(**dict(zip(component.zip_lists.keys(), entity_vals))) == path
 
+    @given(path=st.text())
+    def test_expandable_with_no_wildcards_returns_path_unaltered(self, path: str):
+        component = BidsPartialComponent(zip_lists={})
+        assert itx.one(component.expand(path)) == path
+
+    @given(component=sb_st.expandables(min_values=0, max_values=0, path_safe=True))
+    def test_expandable_with_no_entries_returns_empty_list(self, component: Expandable):
+        path_tpl = bids(**get_wildcard_dict(component.zip_lists))
+        assert component.expand(path_tpl) == []
+
 
 class TestBidsComponentExpand:
     """

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -112,9 +112,14 @@ class TestNormalizeDatabaseArgs:
         pybids_database_dir: str,
         pybids_database_reset: bool,
     ):
-        assert (pybids_database_dir, pybids_database_reset) == _normalize_database_args(
-            None, None, pybids_database_dir, pybids_database_reset
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            assert (
+                pybids_database_dir,
+                pybids_database_reset,
+            ) == _normalize_database_args(
+                None, None, pybids_database_dir, pybids_database_reset
+            )
 
     @given(
         pybidsdb_reset=st.booleans() | st.none(),


### PR DESCRIPTION
Previously returned an empty list. This is different from a component with no entries (but with wildcards), which should return an empty list

Resolves #371
