### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. 
+    # (You don't need to specify `/.github/workflows` for `directory`. 
+    # You can use `directory: "/"`.)
+    directory: "/"
+    # Run on first of each month
+    schedule:
+      interval: "monthly"
+    # PR label
+    labels:
+      - "skip_changelog"
+    # Group to submit a single PR if possible
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Proposed changes

Noted there were still some workflow using old versions (e.g. `actions/checkout@v3`). Setup dependabot config for automatically updating github actions versions and added a `skip_changelog` label to it in order to leave update of github actions out of the release notes. This should make managing the actions versions a little bit easier given the number of workflows we have.

We can consider adding adding the ability to update poetry dependencies to this as well, but I'm not entirely sure how that works. I think it may constrain it to the versions specified by the `pyproject.toml`, but can look into this more in a future PR if we want to go down this road.


## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.