### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,22 @@ updates:
     # PR label
     labels:
       - "skip_changelog"
+    commit-message:
+      prefix: "[.github/workflows]"
     # Group to submit a single PR if possible
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/build-test-container"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "skip_changelog"
+    commit-message:
+      prefix: "[.github/actions/build-test-container]"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Proposed changes

Realised dependabot is only updating workflows found in `.github` and `.github/workflows`. This updates the config to also capture the action found in `.github/actions/build-test-container`. Additionally adds a prefix to the PR title to differentiate PRs for each group. 

Note: Will need to separately add any subdirectories for workflows not found in the `.github` or `.github/workflows` directories. At the moment, the dependabot config does not accept wildcards or multiple inputs for the directory key.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.