### PR TITLE
Trigger CI failure if codecov upload fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           verbose: true
+          fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Apparently pushing to codecov is a fallible step, just had a problem in another branch. But it wasn't reporting an error, so I changed the config here to correct that