### PR TITLE
Update auto-assign actions workflow

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,7 +1,8 @@
 name: Assign reviewer
 
 on:
-  pull_request_target:
+  pull_request_target: # Default: ['opened', 'synchronize', 'reopened']
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   assign:


### PR DESCRIPTION
## Proposed changes

Noticed in #362, the auto-assign action did not automatically assign reviewers when a draft was marked as "Ready for review". The default `pull_request_target` triggers are `opened`, `synchronize`, and `reopened`. This PR explicitly defines these defaults in the workflow and also adds `ready_for_review`, which will trigger the assignment when a draft has been converted.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.