### PR TITLE
Update the warning format to be more readable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ omit = ["snakebids/project_template/**", "snakebids/tests/**"]
 
 [tool.coverage.report]
 exclude_lines = [
-    "pragma: not covered",
+    "pragma: no cover",
     "@overload",
     'class [a-zA-Z0-9_]+\([^)]*Protocol.*\)',
     'if TYPE_CHECKING',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,8 +174,7 @@ markers = [
 omit = ["snakebids/project_template/**", "snakebids/tests/**"]
 
 [tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
+exclude_also = [
     "@overload",
     'class [a-zA-Z0-9_]+\([^)]*Protocol.*\)',
     'if TYPE_CHECKING',

--- a/snakebids/__init__.py
+++ b/snakebids/__init__.py
@@ -3,6 +3,8 @@ __version__ = "0.0.0"
 
 __submodules__ = ["core", "paths"]
 
+from snakebids import _warningformat  # noqa: F401
+
 # isort: split
 # <AUTOGEN_INIT>
 import lazy_loader

--- a/snakebids/_warningformat.py
+++ b/snakebids/_warningformat.py
@@ -34,17 +34,7 @@ def formatwarning(
 
     return WARN_TEMPLATE.format(
         message=textwrap.indent(
-            "\n".join(
-                "\n".join(
-                    textwrap.wrap(
-                        line,
-                        width=80,
-                    )
-                )
-                for line in (
-                    message.args[0] if isinstance(message, Warning) else message
-                ).splitlines()
-            ),
+            message.args[0] if isinstance(message, Warning) else message,
             prefix="  ",
         ),
         category=category.__name__,

--- a/snakebids/_warningformat.py
+++ b/snakebids/_warningformat.py
@@ -26,7 +26,7 @@ def formatwarning(
             import linecache
 
             line = linecache.getline(filename, lineno).rstrip()
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001 # pragma: no cover
             # When a warning is logged during Python shutdown, linecache
             # and the import machinery don't work anymore
             line = None

--- a/snakebids/_warningformat.py
+++ b/snakebids/_warningformat.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import textwrap
+import warnings
+from pathlib import Path
+
+from colorama import Fore, Style
+
+WARN_TEMPLATE = f"""\
+{Fore.RED}{Style.BRIGHT}[{{category}}]{Style.NORMAL} {{filename}}:{{lineno}} \
+{Fore.RESET}{{line}}
+{{message}}
+
+"""
+
+
+def formatwarning(
+    message: Warning | str,
+    category: type[Warning],
+    filename: str,
+    lineno: int,
+    line: str | None,
+):
+    """Format warning messages."""
+    if line is None:
+        with Path(filename).open() as f:
+            for _ in range(lineno):
+                line = f.readline().strip()
+
+    return WARN_TEMPLATE.format(
+        message=textwrap.indent(
+            "\n".join(
+                "\n".join(
+                    textwrap.wrap(
+                        line,
+                        width=80,
+                    )
+                )
+                for line in (
+                    message.args[0] if isinstance(message, Warning) else message
+                ).splitlines()
+            ),
+            prefix="  ",
+        ),
+        category=category.__name__,
+        filename=filename,
+        lineno=lineno,
+        line=line,
+    )
+
+
+warnings.formatwarning = formatwarning

--- a/snakebids/_warningformat.py
+++ b/snakebids/_warningformat.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import textwrap
 import warnings
-from pathlib import Path
 
 from colorama import Fore, Style
 
@@ -23,9 +22,15 @@ def formatwarning(
 ):
     """Format warning messages."""
     if line is None:
-        with Path(filename).open() as f:
-            for _ in range(lineno):
-                line = f.readline().strip()
+        try:
+            import linecache
+
+            line = linecache.getline(filename, lineno)
+        except Exception:  # noqa: BLE001
+            # When a warning is logged during Python shutdown, linecache
+            # and the import machinery don't work anymore
+            line = None
+            linecache = None
 
     return WARN_TEMPLATE.format(
         message=textwrap.indent(

--- a/snakebids/_warningformat.py
+++ b/snakebids/_warningformat.py
@@ -26,7 +26,7 @@ def formatwarning(
             import linecache
 
             line = linecache.getline(filename, lineno).rstrip()
-        except Exception:  # noqa: BLE001 # pragma: no cover
+        except Exception:  # pragma: no cover # noqa: BLE001
             # When a warning is logged during Python shutdown, linecache
             # and the import machinery don't work anymore
             line = None

--- a/snakebids/_warningformat.py
+++ b/snakebids/_warningformat.py
@@ -25,7 +25,7 @@ def formatwarning(
         try:
             import linecache
 
-            line = linecache.getline(filename, lineno)
+            line = linecache.getline(filename, lineno).rstrip()
         except Exception:  # noqa: BLE001
             # When a warning is logged during Python shutdown, linecache
             # and the import machinery don't work anymore

--- a/snakebids/_warningformat.py
+++ b/snakebids/_warningformat.py
@@ -6,7 +6,7 @@ import warnings
 from colorama import Fore, Style
 
 WARN_TEMPLATE = f"""\
-{Fore.RED}{Style.BRIGHT}[{{category}}]{Style.NORMAL} {{filename}}:{{lineno}} \
+{Fore.YELLOW}{Style.BRIGHT}[{{category}}]{Style.NORMAL} {{filename}}:{{lineno}} \
 {Fore.RESET}{{line}}
 {{message}}
 


### PR DESCRIPTION
I find the default formatting of warnings by the python module a bit unreadable, especially given our current tendency to do multiline, complex explanations (for instance, it prints the problematic line after the warning message, which is confusing).

The warnings module does allow reassignment of the format function, and that's what I've attempted here. A screenshot is attached below. There is a bit of a problem with this though, because any other code throwing warnings would be affected, as there's only a single warning module. @kaitj, if you're not comfortable with this, we can close this, this isn't a huge deal.

![image](https://github.com/khanlab/snakebids/assets/87136354/9660b403-bbbe-4a18-b280-9ce51febb83b)
