### PR TITLE
Correctly activate virtualenv in readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,6 +29,5 @@ build:
     post_create_environment:
       - pip install poetry
       - poetry self add "poetry-dynamic-versioning[plugin]"
-      - poetry config virtualenvs.create false
     post_install:
-      - poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH python -m poetry install --with docs


### PR DESCRIPTION
Should fix the failing build in #393 

Corrected as advised [here](https://github.com/python-poetry/poetry/issues/9025)