### PR TITLE
Pin attrs to 22.2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3425,13 +3425,13 @@ standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)",
 
 [[package]]
 name = "virtualenv"
-version = "20.25.2"
+version = "20.25.3"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.25.2-py3-none-any.whl", hash = "sha256:6e1281a57849c8a54da89ba82e5eb7c8937b9d057ff01aaf5bc9afaa3552e90f"},
-    {file = "virtualenv-20.25.2.tar.gz", hash = "sha256:fa7edb8428620518010928242ec17aa7132ae435319c29c1651d1cf4c4173aad"},
+    {file = "virtualenv-20.25.3-py3-none-any.whl", hash = "sha256:8aac4332f2ea6ef519c648d0bc48a5b1d324994753519919bddbb1aff25a104e"},
+    {file = "virtualenv-20.25.3.tar.gz", hash = "sha256:7bb554bbdfeaacc3349fa614ea5bff6ac300fc7c335e9facf3a3bcfc703f45be"},
 ]
 
 [package.dependencies]
@@ -3735,4 +3735,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "d275d944145b48ee56866078eeb57829ed6a69e572a93cbe2653f12a2fde700e"
+content-hash = "4455e27cb0e0d9a2d266d74920ad8bd081c02001bb243031a391babed49905ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ snakemake = [
     { version = ">=7.18.2,<8", python = ">=3.11" },
 ]
 typing-extensions = ">=3.10.0"
-attrs = ">=21.2.0"
+# minimum 22.2 to get "alias" parameter on attrs.field
+attrs = ">=22.2.0"
 boutiques = "^0.5.25"
 more-itertools = ">=8"
 # package developed in complete tandem with snakebids, so no need for a range


### PR DESCRIPTION
Older versions don't have the `alias` parameter in `attrs.field`, which is used in the repository
