### PR TITLE
Allow simult. use of partic incl and excl flags

### DIFF
--- a/snakebids/core/_querying.py
+++ b/snakebids/core/_querying.py
@@ -57,12 +57,6 @@ class PostFilter:
         ValueError
             Raised if both include and exclude values are stipulated.
         """
-        if inclusions is not None and exclusions is not None:
-            msg = (
-                "Cannot define both participant_label and exclude_participant_label at "
-                "the same time"
-            )
-            raise ValueError(msg)
         if inclusions is not None:
             self.inclusions[key] = list(itx.always_iterable(inclusions))
         if exclusions is not None:


### PR DESCRIPTION
The previous restriction was arbitrary. The use of both works according to the set operation:

POPULATION ∩ INCLUDE - EXCLUDE

This will allow better CLI composability.

The tests for include and exclude-participant-label have been rolled into one test.

Resolves #343
