### PR TITLE
Remove reproducible-containers/buildkit-cache-dance

### DIFF
--- a/.github/actions/build-test-container/action.yaml
+++ b/.github/actions/build-test-container/action.yaml
@@ -20,28 +20,22 @@ runs:
     - name: Cache Template Testing Containers
       uses: actions/cache@v4
       with:
-        path: |
-          var-cache-apt
-          var-lib-apt
+        path: /tmp/.buildx-cache
         key: ${{ runner.os }}-test-template-cache-${{ hashFiles('containers/test-template/**') }}-${{ inputs.python-version }}
-    - name: Inject container-test-template-cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v3.0.0
-      with:
-        cache-map: |
-          {
-            "var-cache-apt": "/var/cache/apt",
-            "var-lib-apt": "/var/lib/apt"
-          }
-        skip-extraction: ${{ steps.cache.outputs.cache-hit }}
     - name: Build Docker container for cache
       uses: docker/build-push-action@v5
       with:
         context: containers/test-template
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mod=max
         push: false
         load: ${{ inputs.load == 'true' }}
         tags: snakebids/test-template:${{ inputs.python-version }}
         platforms: linux/amd64
         build-args: |
           PYTHON_VERSION=${{ inputs.python-version }}
+    - name: Move cache
+      shell: bash
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/actions/build-test-container/action.yaml
+++ b/.github/actions/build-test-container/action.yaml
@@ -23,7 +23,7 @@ runs:
         path: container-test-template-cache
         key: ${{ runner.os }}-test-template-cache-${{ hashFiles('containers/test-template/**') }}-${{ inputs.python-version }}
     - name: Inject container-test-template-cache into docker
-      uses: reproducible-containers/buildkit-cache-dance@v2.1.4
+      uses: reproducible-containers/buildkit-cache-dance@v3.0.0
       with:
         cache-source: container-test-template-cache
     - name: Build Docker container for cache

--- a/.github/actions/build-test-container/action.yaml
+++ b/.github/actions/build-test-container/action.yaml
@@ -20,12 +20,19 @@ runs:
     - name: Cache Template Testing Containers
       uses: actions/cache@v4
       with:
-        path: container-test-template-cache
+        path: |
+          var-cache-apt
+          var-lib-apt
         key: ${{ runner.os }}-test-template-cache-${{ hashFiles('containers/test-template/**') }}-${{ inputs.python-version }}
     - name: Inject container-test-template-cache into docker
       uses: reproducible-containers/buildkit-cache-dance@v3.0.0
       with:
-        cache-source: container-test-template-cache
+        cache-map: |
+          {
+            "var-cache-apt": "/var/cache/apt",
+            "var-lib-apt": "/var/lib/apt"
+          }
+        skip-extraction: ${{ steps.cache.outputs.cache-hit }}
     - name: Build Docker container for cache
       uses: docker/build-push-action@v5
       with:


### PR DESCRIPTION
The action was supposed to enable caching of the docker container, but it didn't seem to be working, so I switched to the local cache method described in https://docs.docker.com/build/ci/github-actions/cache/#local-cache