### PR TITLE
Update tutorial for new bidsapp

### DIFF
--- a/docs/bids_app/config.md
+++ b/docs/bids_app/config.md
@@ -144,6 +144,7 @@ A list of analysis levels in the BIDS app. Typically, this will include particip
 
 A mapping from the name of each ``analysis_level`` to the list of rules or files to be run for that analysis level.
 
+(parse-args-config)=
 ### `parse_args`
 
 A dictionary of command-line parameters to make available as part of the BIDS app. Each item of the mapping is passed to [argparse's `add_argument` function](#argparse.ArgumentParser.add_argument). A number of default entries are present in a new snakebids project's config file that structure the BIDS app's CLI, but additional command-line arguments can be added as necessary.

--- a/docs/migration/0.11_to_0.12.md
+++ b/docs/migration/0.11_to_0.12.md
@@ -1,0 +1,32 @@
+(migrate-to-bidsapp)=
+# 0.11 to 0.12+
+
+Snakebids 0.12 introduces a [new, more flexible module](#snakebids.bidsapp) for creating bidsapps. This affects the syntax of the `run.py` file. Older versions used the {class}`snakebids.app.SnakeBidsApp` class to initialize the bidsapp, and this method will still work for the forseeable future. Switching to the new syntax will give access to new plugins and integrations and ensure long term support.
+
+If you haven't heavily modified your `run.py` file, you can transition simply by replacing it with the following:
+
+```python
+#!/usr/bin/env python3
+from pathlib import Path
+
+from snakebids import bidsapp, plugins
+
+app = bidsapp.app(
+    [
+        plugins.SnakemakeBidsApp(Path(__file__).resolve().parent),
+        plugins.BidsValidator(),
+        plugins.Version(distribution="<app_name_here>"),
+    ]
+)
+
+
+def get_parser():
+    """Exposes parser for sphinx doc generation, cwd is the docs dir."""
+    return app.build_parser().parser
+
+
+if __name__ == "__main__":
+    app.run()
+```
+
+The snakemake workflow will work in exactly the same way.

--- a/docs/migration/0.5_to_0.8.md
+++ b/docs/migration/0.5_to_0.8.md
@@ -1,4 +1,8 @@
-# 0.5 to 0.8
+# 0.5 to 0.8+
+
+```{note}
+Be sure to also [migrate](0.11_to_0.12.md) your `run.py` file to the new snakebids 0.12 syntax!
+```
 
 Starting in version 0.8, {func}`snakebids.generate_inputs()` returns a {class}`BidsInputs <snakebids.BidsDataset>` object instead of a {class}`dict <snakebids.BidsDatasetDict>`. This requires a change in the way info is accessed. The previous  {class}`dict <snakebids.BidsDatasetDict>` had top-level keys such as `"input_lists"`. After selecting such a key, you would pass the name of a component to get the information sought:
 

--- a/docs/migration/0.7_to_0.8.md
+++ b/docs/migration/0.7_to_0.8.md
@@ -1,4 +1,4 @@
-# 0.7 to 0.8
+# 0.7 to 0.8+
 
 ````{warning}
 If your code still has bits like this:
@@ -12,6 +12,9 @@ config.update(generate_inputs(
 Check out the [pre-0.6 migration guide](/migration/0.5_to_0.8) to a guide on how to upgrade!
 ````
 
+```{note}
+Be sure to also [migrate](0.11_to_0.12.md) your `run.py` file to the new snakebids 0.12 syntax!
+```
 
 
 ## Default return of {func}`~snakebids.generate_inputs()`

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -7,4 +7,5 @@ Snakebids has rapidly evolved over the last few versions, resulting in a number 
 
 0.5_to_0.8
 0.7_to_0.8
+0.11_to_0.12
 ```

--- a/docs/running_snakebids/overview.md
+++ b/docs/running_snakebids/overview.md
@@ -1,3 +1,4 @@
+(running-snakebids)=
 # Running Snakebids
 
 Once you've specified a snakebids app with a config file and one or more workflow files, you're ready to invoke your snakebids app with the standard BIDS app CLI.

--- a/docs/tutorial/step8/config.yml
+++ b/docs/tutorial/step8/config.yml
@@ -1,10 +1,5 @@
 bids_dir: 'data'
 
-fwhm:
-  - 5
-  - 10
-  - 15
-  - 20
 
 pybids_inputs:
   bold:
@@ -19,52 +14,21 @@ pybids_inputs:
       - task
       - run
 
+analysis_levels:
+ - participant
 
 targets_by_analysis_level:
   participant:
     - ''  # if '', then the first rule is run
 
-analysis_levels: &analysis_levels
- - participant
-
 parse_args:
-  bids_dir:
-    help: |
-      The directory with the input dataset formatted according to the BIDS
-      standard.
-
-  output_dir:
-    help: |
-      The directory where the output files should be stored. If you are running
-      group level analysis this folder should be prepopulated with the results
-      of the participant level analysis.
-
-  analysis_level:
-    help: Level of the analysis that will be performed.
-    choices: *analysis_levels
-
-  --participant_label:
-    help: |
-      The label(s) of the participant(s) that should be analyzed. The label
-      corresponds to sub-<participant_label> from the BIDS spec (so it does not
-      include "sub-"). If this parameter is not provided all subjects should be
-      analyzed. Multiple participants can be specified with a space separated
-      list.
-    nargs: '+'
-
-  --exclude_participant_label:
-    help: |
-      The label(s) of the participant(s) that should be excluded. The label
-      corresponds to sub-<participant_label> from the BIDS spec (so it does not
-      include "sub-"). If this parameter is not provided all subjects should be
-      analyzed. Multiple participants can be specified with a space separated
-      list.
-    nargs: '+'
-
-  --derivatives:
-    help: |
-      Path(s) to a derivatives dataset, for folder(s) that contains multiple
-      derivatives datasets.
-    default: False
-    type: Path
-    nargs: '+'
+  --fwhm:
+    help: >
+      Set the full-width-half-maximum values that should be used for smoothing.
+    type: int
+    nargs: +
+    default:
+      - 5
+      - 10
+      - 15
+      - 20

--- a/docs/tutorial/step8/run.py
+++ b/docs/tutorial/step8/run.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-import os
-from snakebids.app import SnakeBidsApp
+from pathlib import Path
 
+from snakebids import bidsapp, plugins
 
-
-def main():
-    app = SnakeBidsApp(os.path.abspath(os.path.dirname(__file__)))
-    app.run_snakemake()
-
+app = bidsapp.app(
+    [
+        plugins.SnakemakeBidsApp(Path(__file__).resolve().parent),
+    ]
+)
 
 if __name__ == "__main__":
-    main()
+    app.run()


### PR DESCRIPTION
Changes the final step of the tutorial to use the new bidsapp syntax. `fwhm` is brought in a specific example for the way CLI arguments can be created.

Still sparse on details for what `bidsapp.app` actually does and how it can be used. This will come with time.