### PR TITLE
Fix test-counting code

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
         id: count
         run: |
           echo "NUM=$(
-            poetry run pytest --collect-only -q | head -n -2 | wc -l
+            poetry run poe test --co -q --disable-warnings | head -n -2 | wc -l
           )" >> "$GITHUB_OUTPUT"
       - name: Count number of timed tests
         id: timed-count


### PR DESCRIPTION
Old code wasn't counting doctests, and spurious warning lines were being included in the count.