### PR TITLE
Add hook to update and read argv before parsing

### DIFF
--- a/snakebids/bidsapp/hookspecs.py
+++ b/snakebids/bidsapp/hookspecs.py
@@ -46,6 +46,11 @@ def add_cli_arguments(
     """
 
 
+@hookspec(firstresult=True)
+def get_argv(argv: list[str], config: dict[str, Any]) -> list[str]:  # type: ignore
+    """Set or modify the CLI parameters that will be parsed by the parser."""
+
+
 @hookspec
 def handle_unknown_args(args: list[str], config: dict[str, Any]):
     """If ``parse_known_args`` enabled, handle unknown arguments.

--- a/snakebids/bidsapp/run.py
+++ b/snakebids/bidsapp/run.py
@@ -182,7 +182,13 @@ class _Runner:
         """Run all plugins and parse arguments."""
         if not self._processed:
             self.build_parser()
-            namespace, unknown = self.parser.parse_known_args(args=args)
+            args = sys.argv[1:] if args is None else args
+            argv: list[str] | None = self.pm.hook.get_argv(
+                argv=args, config=self.config
+            )
+            namespace, unknown = self.parser.parse_known_args(
+                args=args if argv is None else argv
+            )
             self.pm.hook.handle_unknown_args(args=unknown, config=self.config)
             self.pm.hook.update_cli_namespace(
                 namespace=namespace.__dict__, config=self.config


### PR DESCRIPTION
None of our current plugins use it, but this will be helpful for apps that need to do extra processing on their CLI arguments beyond what can be handled by the bidsapp architecture.