### PR TITLE
Add converters to SnakeBidsApp

### DIFF
--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -12,6 +12,7 @@ can be more flexibly implemented with:
     bidsapp.app([plugins.SnakemakeBidsApp(...)])
 
 """
+
 from __future__ import annotations
 
 import logging
@@ -69,12 +70,16 @@ class SnakeBidsApp:
         DEPRECATED: no-op, use version plugin instead
     """
 
-    snakemake_dir: Path
+    snakemake_dir: Path = attrs.field(converter=Path)
     plugins: list[Callable[[SnakeBidsApp], None | SnakeBidsApp]] = attrs.Factory(list)
     skip_parse_args: bool = False
     _parser: Any = attrs.field(default=None, alias="parser")
-    configfile_path: Path | None = None
-    snakefile_path: Path | None = None
+    configfile_path: Path | None = attrs.field(
+        default=None, converter=attrs.converters.optional(Path)
+    )
+    snakefile_path: Path | None = attrs.field(
+        default=None, converter=attrs.converters.optional(Path)
+    )
     _config: Any = attrs.field(default=None, alias="config")
     version: str | None = None
     args: Any = None

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -40,13 +40,30 @@ def test_arguments_carried_forward(mocker: MockerFixture):
     from snakebids.app import sb_plugins
     from snakebids.bidsapp import run
 
-    mocker.stopall()
     mocker.patch.object(run, "_Runner")
     snakemake = mocker.spy(sb_plugins, "SnakemakeBidsApp")
     SnakeBidsApp(
         Path(),
         configfile_path=Path("config"),
         snakefile_path=Path("Snakefile"),
+    ).run_snakemake()
+    snakemake.assert_called_once_with(
+        snakemake_dir=Path(),
+        configfile_path=Path("config"),
+        snakefile_path=Path("Snakefile"),
+    )
+
+
+def test_str_converted_to_path(mocker: MockerFixture):
+    from snakebids.app import sb_plugins
+    from snakebids.bidsapp import run
+
+    mocker.patch.object(run, "_Runner")
+    snakemake = mocker.spy(sb_plugins, "SnakemakeBidsApp")
+    SnakeBidsApp(
+        "",
+        configfile_path="config",
+        snakefile_path="Snakefile",
     ).run_snakemake()
     snakemake.assert_called_once_with(
         snakemake_dir=Path(),


### PR DESCRIPTION
strings being passed to the arguments in old apps were breaking. Convert now to Paths

