### PR TITLE
Remove return from run method on Runner

### DIFF
--- a/snakebids/bidsapp/run.py
+++ b/snakebids/bidsapp/run.py
@@ -203,4 +203,3 @@ class _Runner:
             self.parse_args(args)
             self.pm.hook.run(config=self.config)
             self._run = True
-

--- a/snakebids/bidsapp/run.py
+++ b/snakebids/bidsapp/run.py
@@ -203,4 +203,4 @@ class _Runner:
             self.parse_args(args)
             self.pm.hook.run(config=self.config)
             self._run = True
-        return self
+

--- a/snakebids/snakemake_compat.pyi
+++ b/snakebids/snakemake_compat.pyi
@@ -1,8 +1,11 @@
 from argparse import ArgumentParser
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Callable, Iterable, Sequence
 
 from snakemake.common import configfile as configfile  # type: ignore
+
+configfile: ModuleType
 
 class WildcardError(Exception): ...
 

--- a/snakebids/tests/test_bidsapp.py
+++ b/snakebids/tests/test_bidsapp.py
@@ -106,9 +106,9 @@ class TestRunner:
 
     def test_run(self):
         app = bidsapp.app(plugins=[self])
-        app.run(args=["default"])
+        assert app.run(args=["default"]) is None
         assert self.hooks_run == 7
-        app.run(args=["default"])
+        assert app.run(args=["default"]) is None
         assert self.hooks_run == 7
 
 


### PR DESCRIPTION
This results in the Runner __repr__ being printed when using app.run as
an entrypoint