### PR TITLE
Prevent bids values with leading 0s in tests

### DIFF
--- a/snakebids/resources/bids_tags.json
+++ b/snakebids/resources/bids_tags.json
@@ -52,7 +52,8 @@
     "run": {
         "tag": "run",
         "before": "[_/\\\\]+run-",
-        "match": "[0-9]{1,5}"
+        "match": "[0-9]{1,5}",
+        "type": "int"
     },
     "proc": {
         "tag": "proc",

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -283,10 +283,20 @@ def zip_lists(
             )
         )
 
+    def filter_ints(type_: str | None):
+        def inner(s: str):
+            if type_ == "int":
+                return int(s) > 0 and not s.startswith("0")
+            return True
+
+        return inner
+
     values = {
         entity: draw(
             st.lists(
-                bids_value(entity.match if restrict_patterns else ".*"),
+                bids_value(entity.match if restrict_patterns else ".*").filter(
+                    filter_ints(entity.type if restrict_patterns else None)
+                ),
                 min_size=min_values,
                 max_size=max_values,
                 unique=(cull or unique),

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -156,6 +156,17 @@ class BidsEntity:
             return self.entity
         return self.tag
 
+    @property
+    def type(self) -> str | None:
+        """Get the type of the entity.
+
+        Returns None if type unspecified.
+        """
+        tags = read_bids_tags()
+        # See note in .before
+        _def: dict[Any, Any] = {}
+        return tags.get(self.entity, _def).get("type")
+
     @classmethod
     def from_tag(cls, tag: str) -> BidsEntity:
         """Return the entity associated with the given tag, if found.


### PR DESCRIPTION
When used with `run`, the leading 0 gets stripped because run is converted into an int. This breaks tests that instantiate a dataset on the filesystem and re-parse it using generate_inputs. Easiest solution is to just to prevent these values entirely

