### PR TITLE
Move upload_coverage to seperate workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,21 +95,6 @@ jobs:
           name: coverage-${{ matrix.python-version }}-${{ matrix.split }}
           path: ./coverage.xml
 
-  upload_coverage:
-    runs-on: ubuntu-latest
-    needs: [ 'test' ]
-    steps:
-      - name: checkout repository
-        uses: actions/checkout@v4
-      - name: download coverage reports
-        uses: actions/download-artifact@v4
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          verbose: true
-          fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 
   deployment_on_base:

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -1,0 +1,26 @@
+
+on:
+  workflow_run:
+    workflows: [Test workflow]
+    types:
+      - completed
+
+jobs:
+  upload_coverage:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+      - name: download coverage reports
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          verbose: true
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The hope is that this will give us access to the CODECOV_TOKEN secret so that we don't hit the rate limit

