### PR TITLE
Fix comparison syntax in tet counting logic

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "NUM=$(jq 'keys | length' .test_durations)" >> "$GITHUB_OUTPUT"
       - name: Test with pytest
-        if: ${{ steps.count.outputs.NUM }} != ${{ steps.timed-count.outputs.NUM }}
+        if: ${{ steps.count.outputs.NUM != steps.timed-count.outputs.NUM }}
         env:
           HYPOTHESIS_PROFILE: pr
         run: >-


### PR DESCRIPTION
Nightly test still not properly comparing the number of tests correctly, this time due to a mistake in logic.

