### PR TITLE
Allow regex from the cli

### DIFF
--- a/snakebids/exceptions.py
+++ b/snakebids/exceptions.py
@@ -35,16 +35,5 @@ class DuplicateComponentError(Exception):
         )
 
 
-class MisspecifiedCliFilterError(Exception):
-    """Raised when a magic CLI filter cannot be parsed."""
-
-    def __init__(self, misspecified_filter: str):
-        super().__init__(
-            "The following filter provided by the CLI could not be parsed: "
-            f"{misspecified_filter}. Filters must be of the form "
-            "{entity}={filter} or {entity}:{REQUIRED|OPTIONAL|NONE} (case-insensitive)."
-        )
-
-
 class SnakebidsPluginError(Exception):
     """Exception raised when a Snakebids plugin encounters a problem."""

--- a/snakebids/plugins/__init__.py
+++ b/snakebids/plugins/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "CliConfig",
     "ComponentEdit",
     "FilterParse",
+    "FilterParseError",
     "InvalidBidsError",
     "Pybidsdb",
     "SnakemakeBidsApp",

--- a/snakebids/plugins/__init__.pyi
+++ b/snakebids/plugins/__init__.pyi
@@ -7,6 +7,7 @@ from .cli_config import (
 from .component_edit import (
     ComponentEdit,
     FilterParse,
+    FilterParseError,
 )
 from .pybidsdb import (
     Pybidsdb,
@@ -29,6 +30,7 @@ __all__ = [
     "CliConfig",
     "ComponentEdit",
     "FilterParse",
+    "FilterParseError",
     "InvalidBidsError",
     "Pybidsdb",
     "SnakemakeBidsApp",

--- a/snakebids/tests/test_plugins/test_component_edit.py
+++ b/snakebids/tests/test_plugins/test_component_edit.py
@@ -183,9 +183,7 @@ class TestAddArguments:
 
         with pytest.raises(
             FilterParseError,
-            match=re.compile(
-                rf"':{re.escape(flag.lower())}' is not a valid filter method"
-            ),
+            match=re.compile(r"is not a valid filter method"),
         ):
             p.parse_args(argv)
 
@@ -207,7 +205,7 @@ class TestAddArguments:
 
         with pytest.raises(
             FilterParseError,
-            match=re.compile(rf"':{re.escape(flag.lower())}' requires a value"),
+            match=re.compile(rf"':{flag}' requires a value"),
         ):
             p.parse_args(argv)
 
@@ -230,9 +228,7 @@ class TestAddArguments:
 
         with pytest.raises(
             FilterParseError,
-            match=re.compile(
-                rf"'entity:{re.escape(flag.lower())}' should not be given a value"
-            ),
+            match=re.compile(rf"'entity:{flag}' should not be given a value"),
         ):
             p.parse_args(argv)
 


### PR DESCRIPTION
Adds :match and :search as valid filter methods, each of which should
take =VALUE.

Expands error handling to give different error messages for different
filter misspecifications.