### PR TITLE
Add CLI argument in BidsValidator plugin

### DIFF
--- a/snakebids/plugins/validator.py
+++ b/snakebids/plugins/validator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import subprocess as sp
@@ -10,6 +11,8 @@ import attr
 
 from snakebids import bidsapp
 from snakebids.exceptions import SnakebidsPluginError
+from snakebids.plugins.base import PluginBase
+from snakebids.utils.utils import text_fold
 
 _logger = logging.getLogger(__name__)
 
@@ -19,11 +22,19 @@ class InvalidBidsError(SnakebidsPluginError):
 
 
 @attr.define
-class BidsValidator:
+class BidsValidator(PluginBase):
     """Perform validation of a BIDS dataset using the bids-validator.
 
     If the dataset is not valid according to the BIDS specifications, an
     InvalidBidsError is raised.
+
+    An argument --skip-bids-validation is added to the CLI. This argument can be
+    overriden by adding an argument with dest ``plugins.validator.skip`` before this
+    plugin runs.
+
+    Two entries are added to config:
+    - ``"plugins.validator.skip"``: Indicates if validation was skipped
+    - ``"plugins.validator.success"``: Indicates if validation succeeded
 
     Parameters
     ----------
@@ -35,8 +46,29 @@ class BidsValidator:
 
     raise_invalid_bids: bool = attr.field(default=True)
 
+    PREFIX = "plugins.validator"
+
     def __eq__(self, other: Any):
         return isinstance(other, self.__class__)
+
+    @bidsapp.hookimpl
+    def add_cli_arguments(self, parser: argparse.ArgumentParser):
+        """Add option to skip validation."""
+        self.try_add_argument(
+            parser,
+            "--skip-bids-validation",
+            dest="skip",
+            action="store_true",
+            default=False,
+            help=text_fold(
+                """
+                Skip validation of BIDS dataset. BIDS validation is performed by default
+                using the bids-validator plugin (if installed/enabled) or with the
+                pybids validator implementation (if bids-validator is not
+                installed/enabled).
+                """
+            ),
+        )
 
     @bidsapp.hookimpl
     def finalize_config(self, config: dict[str, Any]) -> None:

--- a/snakebids/project_template/{{name_slug}}/config/snakebids.yml
+++ b/snakebids/project_template/{{name_slug}}/config/snakebids.yml
@@ -31,16 +31,6 @@ pybids_inputs:
 # configuration for the command-line parameters to make available
 # passed on the argparse add_argument()
 parse_args:
-  --skip-bids-validation:
-    help: |
-      Skip validation of BIDS dataset. BIDS validation is performed by default
-      using the bids-validator plugin (if installed/enabled) or with the pybids
-      validator implementation (if bids-validator is not installed/enabled).
-    dest: "plugins.validator.skip"
-    action: "store_true"
-    default: False
-
-
 
 # Docker and singularity containers may be defined here
 containers:

--- a/snakebids/tests/test_plugins/test_validate_plugin.py
+++ b/snakebids/tests/test_plugins/test_validate_plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import subprocess as sp
 from pathlib import Path
 
@@ -7,6 +8,14 @@ import pytest
 from pytest_mock.plugin import MockerFixture
 
 from snakebids.plugins.validator import BidsValidator, InvalidBidsError
+
+
+def test_skip_validation():
+    val = BidsValidator()
+    parser = argparse.ArgumentParser()
+    val.add_cli_arguments(parser)
+    parsed = parser.parse_args(["--skip-bids-validation"])
+    assert parsed.__dict__["plugins.validator.skip"] is True
 
 
 class TestFinalizeConfig:


### PR DESCRIPTION
Adds a `--skip-bids-validation` argument to the CLI automatically, eliminating the need to add the argument manually. The argument is overridable with the dest `plugins.validator.skip`, so this change is backward compatible.