### PR TITLE
Specify sha and PR number in codecov upload

### DIFF
--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: download coverage reports
         uses: actions/download-artifact@v4
         with:
@@ -23,5 +25,7 @@ jobs:
         with:
           verbose: true
           fail_ci_if_error: true
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_pr: ${{ github.event.workflow_run.pull_requests.number }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
An attempt to fix the fact that coverage is not being done in PRs