### PR TITLE
Update dependencies in template documentation

### DIFF
--- a/snakebids/project_template/{% if create_doc_template %}docs{% endif %}/requirements.txt.jinja
+++ b/snakebids/project_template/{% if create_doc_template %}docs{% endif %}/requirements.txt.jinja
@@ -1,4 +1,3 @@
-docutils<0.18
 sphinx-argparse
 sphinx_rtd_theme
 myst-parser


### PR DESCRIPTION
docutils was pinned to <0.18 for some reason. That version is not supported by the latest sphinx. I've removed the line entirely to let sphinx figure it out.

@akhanf, can you have a look at this one? I think you originally made the documentation requirements, so I want to see if I'm missing anything here.