### PR TITLE
Transition from zip-list to entry core

### DIFF
--- a/snakebids/core/_table.py
+++ b/snakebids/core/_table.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, Mapping
+
+import attrs
+import more_itertools as itx
+
+from snakebids.io.printing import format_zip_lists
+from snakebids.types import ZipList, ZipListLike
+from snakebids.utils.containers import ContainerBag, MultiSelectDict, RegexContainer
+
+if TYPE_CHECKING:
+
+    def wcard_tuple(x: Iterable[str]) -> tuple[str, ...]:
+        return tuple(x)
+
+    def entries_list(x: Iterable[tuple[str, ...]]) -> list[tuple[str, ...]]:
+        return list(x)
+
+    def liststr() -> list[str]:
+        return []
+else:
+    wcard_tuple = tuple
+    entries_list = list
+    liststr = list
+
+
+@attrs.frozen(kw_only=True)
+class BidsTable:
+    """Container holding the entries of a BidsComponent."""
+
+    wildcards: tuple[str, ...] = attrs.field(converter=wcard_tuple)
+    entries: list[tuple[str, ...]] = attrs.field(converter=entries_list)
+
+    def __bool__(self):
+        """Return True if one or more entries, otherwise False."""
+        return bool(self.entries)
+
+    def __eq__(self, other: BidsTable | object):
+        if not isinstance(other, self.__class__):
+            return False
+        if set(self.wildcards) != set(other.wildcards):
+            return False
+        if len(self.entries) != len(other.entries):
+            return False
+        if self.wildcards == other.wildcards:
+            return sorted(self.entries) == sorted(other.entries)
+        ixs = [other.wildcards.index(w) for w in self.wildcards]
+        entries = self.entries.copy()
+        try:
+            for entry in other.entries:
+                sorted_entry = tuple(entry[i] for i in ixs)
+                entries.remove(sorted_entry)
+        except ValueError:
+            return False
+        return True
+
+    @classmethod
+    def from_dict(cls, d: ZipListLike):
+        """Construct BidsTable from a mapping of entities to value lists."""
+        lengths = {len(val) for val in d.values()}
+        if len(lengths) > 1:
+            msg = "each entity must have the same number of values"
+            raise ValueError(msg)
+        return cls(wildcards=d.keys(), entries=zip(*d.values()))
+
+    def to_dict(self) -> ZipList:
+        """Convert into a zip_list."""
+        if not self.entries:
+            return MultiSelectDict(zip(self.wildcards, itx.repeatfunc(liststr)))
+        return MultiSelectDict(zip(self.wildcards, map(list, zip(*self.entries))))
+
+    def pformat(self, max_width: int | float | None = None, tabstop: int = 4) -> str:
+        """Pretty-format."""
+        return format_zip_lists(self.to_dict(), max_width=max_width, tabstop=tabstop)
+
+    def get(self, wildcard: str):
+        """Get values for a single wildcard."""
+        index = self.wildcards.index(wildcard)
+        return [entry[index] for entry in self.entries]
+
+    def pick(self, wildcards: Iterable[str]):
+        """Select wildcards without deduplication."""
+        # Use dict.fromkeys for de-duplication to preserve order
+        indices = [self.wildcards.index(w) for w in dict.fromkeys(wildcards)]
+
+        entries = [tuple(entry[i] for i in indices) for entry in self.entries]
+
+        return self.__class__(wildcards=wildcards, entries=entries)
+
+    def filter(
+        self,
+        filters: Mapping[str, Iterable[str] | str],
+        regex_search: bool = False,
+    ):
+        """Apply filtering operation."""
+        valid_filters = set(self.wildcards)
+        if regex_search:
+            filter_sets = {
+                self.wildcards.index(key): ContainerBag(
+                    *(RegexContainer(r) for r in itx.always_iterable(vals))
+                )
+                for key, vals in filters.items()
+                if key in valid_filters
+            }
+        else:
+            filter_sets = {
+                self.wildcards.index(key): set(itx.always_iterable(vals))
+                for key, vals in filters.items()
+                if key in valid_filters
+            }
+
+        keep = [
+            entry
+            for entry in self.entries
+            if all(
+                i not in filter_sets or val in filter_sets[i]
+                for i, val in enumerate(entry)
+            )
+        ]
+
+        return self.__class__(wildcards=self.wildcards, entries=keep)

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -7,12 +7,12 @@ import logging
 import os
 import re
 import warnings
-from collections import defaultdict
 from pathlib import Path
 from typing import (
     Any,
     Iterable,
     Literal,
+    cast,
     overload,
 )
 
@@ -25,20 +25,20 @@ from snakebids.core._querying import (
     UnifiedFilter,
     get_matching_files,
 )
+from snakebids.core._table import BidsTable
 from snakebids.core.datasets import BidsComponent, BidsDataset, BidsDatasetDict
-from snakebids.core.filtering import filter_list
 from snakebids.exceptions import (
+    BidsParseError,
     ConfigError,
     DuplicateComponentError,
     RunError,
 )
 from snakebids.snakemake_compat import Snakemake
-from snakebids.types import InputConfig, InputsConfig, ZipList
-from snakebids.utils.snakemake_io import glob_wildcards
+from snakebids.types import InputConfig, InputsConfig
+from snakebids.utils.snakemake_io import glob_wildcards_to_entries
 from snakebids.utils.utils import (
     DEPRECATION_FLAG,
     BidsEntity,
-    BidsParseError,
     get_first_dir,
 )
 
@@ -561,8 +561,11 @@ def _get_component(
 
     if "custom_path" in component:
         path = component["custom_path"]
-        zip_lists = _parse_custom_path(path, filters=filters)
-        return BidsComponent(name=input_name, path=path, zip_lists=zip_lists)
+        return BidsComponent(
+            name=input_name,
+            path=path,
+            table=_parse_custom_path(path, filters=filters),
+        )
 
     if bids_layout is None:
         msg = (
@@ -571,7 +574,8 @@ def _get_component(
         )
         raise RunError(msg)
 
-    zip_lists: dict[str, list[str]] = defaultdict(list)
+    entries: list[tuple[str, ...]] = []
+    wildcards: tuple[str, ...] = ()
     paths: set[str] = set()
     try:
         matching_files = get_matching_files(bids_layout, filters)
@@ -579,15 +583,15 @@ def _get_component(
         raise err.get_config_error(input_name) from err
 
     for img in matching_files:
-        wildcards: list[str] = [
-            wildcard
+        entities = [
+            BidsEntity.normalize(cast(str, wildcard))
             for wildcard in component.get("wildcards", [])
             if wildcard in img.entities
         ]
-        _logger.debug("Wildcards %s found entities for %s", wildcards, img.path)
+        _logger.debug("Wildcards %s found entities for %s", entities, img.path)
 
         try:
-            path, parsed_wildcards = _parse_bids_path(img.path, wildcards)
+            path, parsed_wildcards = _parse_bids_path(img.path, entities)
         except BidsParseError as err:
             msg = (
                 "Parsing failed:\n"
@@ -608,13 +612,22 @@ def _get_component(
             )
             raise ConfigError(msg) from err
 
-        for wildcard_name, value in parsed_wildcards.items():
-            zip_lists[wildcard_name].append(value)
-
+        entries.append(parsed_wildcards)
         paths.add(path)
+        wildcards = tuple(entity.wildcard for entity in entities)
 
-    # now, check to see if unique
-    if len(paths) == 0:
+    try:
+        path = itx.one(paths, too_short=TypeError)
+    except ValueError:
+        msg = (
+            f"Multiple path templates for one component. Use --filter_{input_name} to "
+            f"narrow your search or --wildcards_{input_name} to make the template more "
+            "generic.\n"
+            f"\tcomponent = {input_name!r}\n"
+            f"\tpath_templates = [\n\t\t" + ",\n\t\t".join(map(repr, paths)) + "\n\t]\n"
+        ).expandtabs(4)
+        raise ConfigError(msg) from None
+    except TypeError:
         _logger.warning(
             "No input files found for snakebids component %s:\n"
             "    filters:\n%s\n"
@@ -631,32 +644,23 @@ def _get_component(
             ),
         )
         return None
-    try:
-        path = itx.one(paths)
-    except ValueError as err:
-        msg = (
-            f"Multiple path templates for one component. Use --filter_{input_name} to "
-            f"narrow your search or --wildcards_{input_name} to make the template more "
-            "generic.\n"
-            f"\tcomponent = {input_name!r}\n"
-            f"\tpath_templates = [\n\t\t" + ",\n\t\t".join(map(repr, paths)) + "\n\t]\n"
-        ).expandtabs(4)
-        raise ConfigError(msg) from err
 
     if filters.has_empty_postfilter:
         return BidsComponent(
-            name=input_name, path=path, zip_lists={key: [] for key in zip_lists}
+            name=input_name, path=path, table=BidsTable(wildcards=wildcards, entries=[])
         )
 
-    return BidsComponent(name=input_name, path=path, zip_lists=zip_lists).filter(
-        regex_search=True, **filters.post_exclusions
-    )
+    return BidsComponent(
+        name=input_name,
+        path=path,
+        table=BidsTable(wildcards=wildcards, entries=entries),
+    ).filter(regex_search=True, **filters.post_exclusions)
 
 
 def _parse_custom_path(
     input_path: Path | str,
     filters: UnifiedFilter,
-) -> ZipList:
+) -> BidsTable:
     """Glob wildcards from a custom path and apply filters.
 
     This replicates pybids path globbing for any custom path. Input path should have
@@ -681,27 +685,29 @@ def _parse_custom_path(
     -------
     input_zip_list, input_list, input_wildcards
     """
-    if not (wildcards := glob_wildcards(input_path)):
+    if (table := glob_wildcards_to_entries(input_path)) is None:
         _logger.warning("No wildcards defined in %s", input_path)
+        return BidsTable(wildcards=(), entries=[])
 
     # Log an error if no matches found
-    if len(itx.first(wildcards.values())) == 0:
+    if not table:
         _logger.error("No matching files for %s", input_path)
-        return wildcards
+        return table
 
     # Return the output values, running filtering on the zip_lists
-    result = filter_list(
-        wildcards,
+    result = table.filter(
         filters.without_bools,
         regex_search=False,
     )
     if not filters.post_exclusions:
         return result
 
-    return filter_list(result, filters.post_exclusions, regex_search=True)
+    return result.filter(filters.post_exclusions, regex_search=True)
 
 
-def _parse_bids_path(path: str, entities: Iterable[str]) -> tuple[str, dict[str, str]]:
+def _parse_bids_path(
+    path: str, entities: Iterable[BidsEntity]
+) -> tuple[str, tuple[str, ...]]:
     """Replace parameters in an bids path with the given wildcard {tags}.
 
     Parameters
@@ -714,40 +720,31 @@ def _parse_bids_path(path: str, entities: Iterable[str]) -> tuple[str, dict[str,
 
     Returns
     -------
-    path : str
+    path
         Original path with the original entities replaced with wildcards.
         (e.g. "root/sub-{subject}/ses-{session}/sub-{subject}_ses-{session}_{suffix}")
-    matches : iterable of (wildcard, value)
+    matches
         The values matched with each wildcard
     """
     # If path is relative, we need to get a slash in front of it to ensure parsing works
     # correctly. So prepend "./" or ".\" and run function again, then strip before
     # returning
     if not os.path.isabs(path) and get_first_dir(path) != ".":
-        path_, wildcard_values = _parse_bids_path(os.path.join(".", path), entities)
-        return str(Path(path_)), wildcard_values
+        path_, vals = _parse_bids_path(os.path.join(".", path), entities)
+        return str(Path(path_)), vals
 
-    entities = list(entities)
+    matches: list[tuple[BidsEntity, re.Match[str]]] = []
+    wildcard_values: list[str] = []
+    for entity in entities:
+        values: list[str] = []
+        for match in re.finditer(entity.regex, path):
+            matches.append((entity, match))
+            values.append(match.group(2))
+        if len(values) == 0:
+            raise BidsParseError(path=path, entity=entity)
+        wildcard_values.append(values[0])
 
-    matches = sorted(
-        (
-            (entity, match)
-            for entity in map(BidsEntity, entities)
-            for match in re.finditer(entity.regex, path)
-        ),
-        key=lambda match: match[1].start(2),
-    )
-
-    wildcard_values: dict[str, str] = {
-        entity.wildcard: match.group(2) for entity, match in matches
-    }
-    if len(wildcard_values) != len(entities):
-        unmatched = (
-            set(map(BidsEntity, entities))
-            .difference(match[0] for match in matches)
-            .pop()
-        )
-        raise BidsParseError(path=path, entity=unmatched)
+    matches = sorted(matches, key=lambda match: match[1].start(2))
 
     num_matches = len(matches)
     new_path: list[str] = []
@@ -758,7 +755,7 @@ def _parse_bids_path(path: str, entities: Iterable[str]) -> tuple[str, dict[str,
         new_path.append(path[start:end].replace("{", "{{").replace("}", "}}"))
         if i < num_matches:
             new_path.append(f"{{{matches[i][0].wildcard}}}")
-    return "".join(new_path), wildcard_values
+    return "".join(new_path), tuple(wildcard_values)
 
 
 def get_wildcard_constraints(image_types: InputsConfig) -> dict[str, str]:

--- a/snakebids/exceptions.py
+++ b/snakebids/exceptions.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from snakebids.utils.utils import BidsEntity
+
 
 class ConfigError(Exception):
     """Exception raised for errors with the Snakebids config."""
@@ -37,3 +39,12 @@ class DuplicateComponentError(Exception):
 
 class SnakebidsPluginError(Exception):
     """Exception raised when a Snakebids plugin encounters a problem."""
+
+
+class BidsParseError(Exception):
+    """Exception raised for errors encountered in the parsing of Bids paths."""
+
+    def __init__(self, path: str, entity: BidsEntity) -> None:
+        self.path = path
+        self.entity = entity
+        super().__init__(path, entity)

--- a/snakebids/tests/helpers.py
+++ b/snakebids/tests/helpers.py
@@ -26,11 +26,12 @@ from hypothesis import HealthCheck, example, settings
 from typing_extensions import ParamSpec
 
 from snakebids import bids_factory
+from snakebids.core._table import BidsTable
 from snakebids.core.datasets import BidsDataset
 from snakebids.core.input_generation import generate_inputs
 from snakebids.paths import specs
-from snakebids.types import InputsConfig, ZipList, ZipListLike
-from snakebids.utils.containers import MultiSelectDict, UserDictPy38
+from snakebids.types import InputsConfig, ZipListLike
+from snakebids.utils.containers import UserDictPy38
 from snakebids.utils.utils import BidsEntity
 
 _T = TypeVar("_T")
@@ -38,10 +39,10 @@ _T_contra = TypeVar("_T_contra", contravariant=True)
 _P = ParamSpec("_P")
 
 
-def get_zip_list(
+def get_bids_entries(
     entities: Iterable[BidsEntity | str], combinations: Iterable[tuple[str, ...]]
-) -> ZipList:
-    """Return a zip list from iterables of entities and value combinations
+) -> BidsTable:
+    """Return a BidsEntries from iterables of entities and value combinations
 
     Parameters
     ----------
@@ -56,16 +57,9 @@ def get_zip_list(
     dict[str, list[str]]
         zip_list representation of entity-value combinations
     """
-
-    def strlist() -> list[str]:
-        return []
-
-    lists: Iterable[Sequence[str]] = list(zip(*combinations)) or itx.repeatfunc(strlist)
-    return MultiSelectDict(
-        {
-            BidsEntity(str(entity)).wildcard: list(combs)
-            for entity, combs in zip(entities, lists)
-        }
+    return BidsTable(
+        wildcards=(BidsEntity(str(entity)).wildcard for entity in entities),
+        entries=combinations,
     )
 
 

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -19,6 +19,7 @@ import hypothesis.strategies as st
 from bids.layout import Config as BidsConfig
 from hypothesis import assume
 
+from snakebids.core._table import BidsTable
 from snakebids.core.datasets import (
     BidsComponent,
     BidsComponentRow,
@@ -26,7 +27,7 @@ from snakebids.core.datasets import (
     BidsPartialComponent,
 )
 from snakebids.tests import helpers
-from snakebids.types import Expandable, InputConfig, InputsConfig, ZipList
+from snakebids.types import Expandable, InputConfig, InputsConfig
 from snakebids.utils.containers import ContainerBag, MultiSelectDict
 from snakebids.utils.utils import BidsEntity
 
@@ -152,10 +153,9 @@ def bids_path(
 
     extras = (
         {
-            k: v[0].replace("{", "{{").replace("}", "}}")
+            k: v.replace("{", "{{").replace("}", "}}")
             for k, v in draw(
-                zip_lists(
-                    max_values=1,
+                bids_entries(
                     max_entities=2,
                     blacklist_entities=ContainerBag(
                         blacklist_entities if blacklist_entities is not None else [],
@@ -260,7 +260,48 @@ def inputs_configs(
 
 
 @st.composite
-def zip_lists(
+def bids_entries(
+    draw: st.DrawFn,
+    *,
+    min_entities: int = 1,
+    max_entities: int = 5,
+    entities: list[BidsEntity] | None = None,
+    blacklist_entities: Container[BidsEntity | str] | None = None,
+    whitelist_entities: Container[BidsEntity | str] | None = None,
+    restrict_patterns: bool = False,
+) -> dict[str, str]:
+    # Generate entity value-pairs for different "file types"
+
+    if entities is None:
+        entities = draw(
+            bids_entity_lists(
+                min_size=min_entities,
+                max_size=max_entities,
+                blacklist_entities=blacklist_entities,
+                whitelist_entities=whitelist_entities,
+            )
+        )
+
+    def filter_ints(type_: str | None):
+        def inner(s: str):
+            if type_ == "int":
+                return int(s) > 0 and not s.startswith("0")
+            return True
+
+        return inner
+
+    return {
+        BidsEntity(entity).wildcard: draw(
+            bids_value(entity.match if restrict_patterns else ".*").filter(
+                filter_ints(entity.type if restrict_patterns else None)
+            )
+        )
+        for entity in entities
+    }
+
+
+@st.composite
+def bids_tables(
     draw: st.DrawFn,
     *,
     min_entities: int = 1,
@@ -273,7 +314,7 @@ def zip_lists(
     restrict_patterns: bool = False,
     unique: bool = False,
     cull: bool = True,
-) -> ZipList:
+) -> BidsTable:
     # Generate multiple entity sets for different "file types"
 
     if entities is None:
@@ -321,7 +362,10 @@ def zip_lists(
         if cull and len(combinations)
         else combinations
     )
-    return helpers.get_zip_list(values, used_combinations)
+    return BidsTable(
+        wildcards=(BidsEntity(entity).wildcard for entity in values),
+        entries=used_combinations,
+    )
 
 
 @st.composite
@@ -401,8 +445,8 @@ def bids_partial_components(
                 ),
             )
         )
-    zip_list = draw(
-        zip_lists(
+    table = draw(
+        bids_tables(
             min_entities=min_entities,
             max_entities=max_entities,
             min_values=min_values,
@@ -416,7 +460,7 @@ def bids_partial_components(
         )
     )
 
-    return BidsPartialComponent(zip_lists=zip_list)
+    return BidsPartialComponent(table=table)
 
 
 @st.composite
@@ -466,7 +510,7 @@ def bids_components(
     return BidsComponent(
         name=name or draw(bids_value()),
         path=str(path),
-        zip_lists=partial.zip_lists,
+        table=partial._table,
     )
 
 

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -25,6 +25,7 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_mock import MockerFixture
 
 from snakebids.core._querying import PostFilter, UnifiedFilter, get_matching_files
+from snakebids.core._table import BidsTable
 from snakebids.core.datasets import BidsComponent, BidsDataset
 from snakebids.core.input_generation import (
     _all_custom_paths,
@@ -35,7 +36,7 @@ from snakebids.core.input_generation import (
     _parse_custom_path,
     generate_inputs,
 )
-from snakebids.exceptions import ConfigError, PybidsError, RunError
+from snakebids.exceptions import BidsParseError, ConfigError, PybidsError, RunError
 from snakebids.paths._presets import bids
 from snakebids.snakemake_compat import expand as sb_expand
 from snakebids.tests import strategies as sb_st
@@ -46,14 +47,14 @@ from snakebids.tests.helpers import (
     create_dataset,
     create_snakebids_config,
     example_if,
+    get_bids_entries,
     get_bids_path,
-    get_zip_list,
     mock_data,
     reindex_dataset,
 )
 from snakebids.types import InputsConfig
 from snakebids.utils.containers import MultiSelectDict
-from snakebids.utils.utils import DEPRECATION_FLAG, BidsEntity, BidsParseError
+from snakebids.utils.utils import DEPRECATION_FLAG, BidsEntity
 
 T = TypeVar("T")
 
@@ -314,9 +315,9 @@ class TestFilterBools:
                 "0": BidsComponent(
                     name="0",
                     path="ce-{ce}_space-{space}",
-                    zip_lists={"ce": ["0"], "space": ["0"]},
+                    table={"ce": "0", "space": "0"},
                 ),
-                "1": BidsComponent(name="1", path="ce-{ce}", zip_lists={"ce": ["0"]}),
+                "1": BidsComponent(name="1", path="ce-{ce}", table={"ce": ["0"]}),
             }
         )
     )
@@ -326,12 +327,12 @@ class TestFilterBools:
                 "1": BidsComponent(
                     name="1",
                     path="sub-{subject}/{datatype}/sub-{subject}",
-                    zip_lists={"subject": ["0"], "datatype": ["anat"]},
+                    table={"subject": ["0"], "datatype": ["anat"]},
                 ),
                 "0": BidsComponent(
                     name="0",
                     path="sub-{subject}/sub-{subject}",
-                    zip_lists={"subject": ["0"]},
+                    table={"subject": ["0"]},
                 ),
             }
         )
@@ -342,12 +343,12 @@ class TestFilterBools:
                 "1": BidsComponent(
                     name="1",
                     path="sub-{subject}/sub-{subject}_{suffix}.foo",
-                    zip_lists={"subject": ["0"], "suffix": ["bar"]},
+                    table={"subject": ["0"], "suffix": ["bar"]},
                 ),
                 "0": BidsComponent(
                     name="0",
                     path="{suffix}.foo",
-                    zip_lists={"suffix": ["bar"]},
+                    table=({"suffix": ["bar"]}),
                 ),
             }
         )
@@ -386,7 +387,12 @@ class TestFilterBools:
         data = generate_inputs(root, pybids_inputs)
         assert data == expected
 
-    @allow_function_scoped
+    @settings(
+        deadline=800,
+        suppress_health_check=[
+            HealthCheck.function_scoped_fixture,
+        ],
+    )
     @given(
         template=sb_st.bids_components(
             name="template", restrict_patterns=True, unique=True, extra_entities=False
@@ -449,7 +455,12 @@ class TestFilterBools:
         result = generate_inputs(root, pybids_inputs)
         assert result == BidsDataset({"target": dataset["target"]})
 
-    @allow_function_scoped
+    @settings(
+        deadline=800,
+        suppress_health_check=[
+            HealthCheck.function_scoped_fixture,
+        ],
+    )
     @given(
         template=sb_st.bids_components(
             name="template", restrict_patterns=True, unique=True, extra_entities=False
@@ -519,10 +530,12 @@ class TestFilterMethods:
         component=BidsComponent(
             name="template",
             path="sub-{subject}/ses-{session}/sub-{subject}_ses-{session}",
-            zip_lists={
-                "session": ["0A", "0a"],
-                "subject": ["0", "00"],
-            },
+            table=(
+                {
+                    "session": ["0A", "0a"],
+                    "subject": ["0", "00"],
+                }
+            ),
         ),
         data=mock_data(["0a"]),
     )
@@ -530,10 +543,12 @@ class TestFilterMethods:
         component=BidsComponent(
             name="template",
             path="sub-{subject}/sub-{subject}_mt-{mt}",
-            zip_lists={
-                "subject": ["0", "00"],
-                "mt": ["on", "on"],
-            },
+            table=(
+                {
+                    "subject": ["0", "00"],
+                    "mt": ["on", "on"],
+                }
+            ),
         ),
         data=mock_data(["0"]),
     )
@@ -635,22 +650,27 @@ class TestFilterMethods:
     )
     def test_regex_search_selects_paths(self, tmpdir: Path, component: BidsComponent):
         root = tempfile.mkdtemp(dir=tmpdir)
-        entity = itx.first(component.entities)
-        assume(f"prefix{component[entity][0]}suffix" not in component.entities[entity])
-        zip_lists = {
-            ent: (
-                [*value, f"prefix{value[0]}suffix"]
-                if ent is entity
-                else [*value, value[0]]
-            )
-            for ent, value in component.zip_lists.items()
-        }
+        entity = component._table.wildcards[0]
+        assume(
+            f"prefix{component._table.entries[0][0]}suffix"
+            not in component.entities[entity]
+        )
+        entries = [
+            *component._table.entries,
+            (
+                f"prefix{component._table.entries[0][0]}suffix",
+                *component._table.entries[0][1:],
+            ),
+        ]
         dataset = BidsDataset.from_iterable(
             [
                 attrs.evolve(
                     component,
                     path=os.path.join(root, component.path),
-                    zip_lists=zip_lists,
+                    table=attrs.evolve(
+                        component._table,
+                        entries=entries,
+                    ),
                 )
             ]
         )
@@ -677,7 +697,7 @@ class TestFilterMethods:
         component=BidsComponent(
             name="template",
             path="sub-{subject}/sub-{subject}_mt-{mt}",
-            zip_lists={
+            table={
                 "subject": ["0", "00"],
                 "mt": ["on", "on"],
             },
@@ -788,7 +808,7 @@ class TestFilterMethods:
         self, tmpdir: Path, methods: list[str]
     ):
         dataset = BidsDataset.from_iterable(
-            [BidsComponent(zip_lists={}, name="template", path=str(tmpdir))]
+            [BidsComponent(table={}, name="template", path=str(tmpdir))]
         )
         create_dataset("", dataset)
         pybids_inputs: InputsConfig = {
@@ -804,7 +824,7 @@ class TestFilterMethods:
     @pytest.mark.disable_fakefs(True)
     def test_filter_with_no_methods_raises_error(self, tmpdir: Path):
         dataset = BidsDataset.from_iterable(
-            [BidsComponent(zip_lists={}, name="template", path=str(tmpdir))]
+            [BidsComponent(table={}, name="template", path=str(tmpdir))]
         )
         create_dataset("", dataset)
         pybids_inputs: InputsConfig = {
@@ -827,7 +847,7 @@ class TestFilterMethods:
     )
     def test_filter_with_invalid_method_raises_error(self, tmpdir: Path, method: str):
         dataset = BidsDataset.from_iterable(
-            [BidsComponent(zip_lists={}, name="template", path=str(tmpdir))]
+            [BidsComponent(table={}, name="template", path=str(tmpdir))]
         )
         create_dataset("", dataset)
         pybids_inputs: InputsConfig = {
@@ -872,7 +892,7 @@ class TestAbsentConfigEntries:
             pybids_config=str(Path(__file__).parent / "data" / "custom_config.json"),
         )
         template = BidsDataset(
-            {"t1": BidsComponent(name="t1", path=config["t1"].path, zip_lists=zip_list)}
+            {"t1": BidsComponent(name="t1", path=config["t1"].path, table=zip_list)}
         )
         # Order of the subjects is not deterministic
         assert template == config
@@ -897,7 +917,13 @@ class TestAbsentConfigEntries:
             pybids_config=str(Path(__file__).parent / "data" / "custom_config.json"),
         )
         template = BidsDataset(
-            {"t1": BidsComponent(name="t1", path=config["t1"].path, zip_lists={})}
+            {
+                "t1": BidsComponent(
+                    name="t1",
+                    path=config["t1"].path,
+                    table=BidsTable(wildcards=[], entries=[()]),
+                )
+            }
         )
         assert template == config
         assert config.subj_wildcards == {"subject": "{subject}"}
@@ -1064,11 +1090,11 @@ class TestCustomPaths:
 
         # Test without any filters
         result = _parse_custom_path(test_path, UnifiedFilter.from_filter_dict({}))
-        zip_lists = get_zip_list(entities, it.product(*entities.values()))
+        zip_lists = get_bids_entries(entities, it.product(*entities.values()))
         assert BidsComponent(
-            name="foo", path=get_bids_path(zip_lists), zip_lists=zip_lists
+            name="foo", path=get_bids_path(zip_lists.wildcards), table=zip_lists
         ) == BidsComponent(
-            name="foo", path=get_bids_path(result), zip_lists=MultiSelectDict(result)
+            name="foo", path=get_bids_path(result.wildcards), table=result
         )
 
     @settings(deadline=400, suppress_health_check=[HealthCheck.function_scoped_fixture])
@@ -1082,21 +1108,19 @@ class TestCustomPaths:
         test_path = self.generate_test_directory(entities, template, temp_dir)
 
         # Test with filters
-        result_filtered = MultiSelectDict(
-            _parse_custom_path(test_path, UnifiedFilter.from_filter_dict(filters))
+        result_filtered = _parse_custom_path(
+            test_path, UnifiedFilter.from_filter_dict(filters)
         )
-        zip_lists = MultiSelectDict(
-            {
-                # Start with empty lists for each key, otherwise keys will be missing
-                **{key: [] for key in entities},
-                # Override entities with relevant filters before making zip lists
-                **get_zip_list(entities, it.product(*{**entities, **filters}.values())),
-            }
+        zip_lists = get_bids_entries(
+            entities, it.product(*{**entities, **filters}.values())
         )
+
         assert BidsComponent(
-            name="foo", path=get_bids_path(zip_lists), zip_lists=zip_lists
+            name="foo", path=get_bids_path(zip_lists.wildcards), table=zip_lists
         ) == BidsComponent(
-            name="foo", path=get_bids_path(result_filtered), zip_lists=result_filtered
+            name="foo",
+            path=get_bids_path(result_filtered.wildcards),
+            table=result_filtered,
         )
 
     @settings(
@@ -1114,29 +1138,22 @@ class TestCustomPaths:
         exclude_filters = PostFilter()
         for key, values in filters.items():
             exclude_filters.add_filter(key, None, values)
-        result_excluded = MultiSelectDict(
-            _parse_custom_path(
-                test_path, UnifiedFilter.from_filter_dict({}, exclude_filters)
-            )
+        result_excluded = _parse_custom_path(
+            test_path, UnifiedFilter.from_filter_dict({}, exclude_filters)
         )
 
         entities_excluded = {
             entity: [value for value in values if value not in filters.get(entity, [])]
             for entity, values in entities.items()
         }
-        zip_lists = MultiSelectDict(
-            {
-                # Start with empty lists for each key, otherwise keys will be missing
-                **{key: [] for key in entities},
-                # Override entities with relevant filters before making zip lists
-                **get_zip_list(entities, it.product(*entities_excluded.values())),
-            }
-        )
+        zip_lists = get_bids_entries(entities, it.product(*entities_excluded.values()))
 
         assert BidsComponent(
-            name="foo", path=get_bids_path(zip_lists), zip_lists=zip_lists
+            name="foo", path=get_bids_path(zip_lists.wildcards), table=zip_lists
         ) == BidsComponent(
-            name="foo", path=get_bids_path(result_excluded), zip_lists=result_excluded
+            name="foo",
+            path=get_bids_path(result_excluded.wildcards),
+            table=result_excluded,
         )
 
     @given(
@@ -1201,7 +1218,7 @@ def test_custom_pybids_config(tmpdir: Path):
                     foo="{foo}",
                     suffix="T1w.nii.gz",
                 ),
-                zip_lists={"foo": ["0", "1"], "subject": ["001", "001"]},
+                table={"foo": ["0", "1"], "subject": ["001", "001"]},
             )
         }
     )
@@ -1286,7 +1303,7 @@ def test_t1w():
             "t1": BidsComponent(
                 name="t1",
                 path=result["t1"].path,
-                zip_lists={"acq": ["mprage", "mprage"], "subject": ["001", "002"]},
+                table={"acq": ["mprage", "mprage"], "subject": ["001", "002"]},
             )
         }
     )
@@ -1325,16 +1342,10 @@ def test_t1w():
             "scan": BidsComponent(
                 name="scan",
                 path=result["scan"].path,
-                zip_lists={
-                    "acq": [
-                        "mprage",
-                    ],
-                    "subject": [
-                        "001",
-                    ],
-                    "suffix": [
-                        "T1w",
-                    ],
+                table={
+                    "acq": ["mprage"],
+                    "subject": ["001"],
+                    "suffix": ["T1w"],
                 },
             )
         }
@@ -1390,7 +1401,7 @@ def test_t1w():
                 "t1": BidsComponent(
                     name="t1",
                     path=result["t1"].path,
-                    zip_lists={
+                    table={
                         "acq": ["mprage", "mprage"],
                         "subject": ["001", "002"],
                     },
@@ -1398,7 +1409,7 @@ def test_t1w():
                 "t2": BidsComponent(
                     name="t2",
                     path=result["t2"].path,
-                    zip_lists={"subject": ["002"]},
+                    table={"subject": ["002"]},
                 ),
             }
         )
@@ -1535,7 +1546,7 @@ def test_get_lists_from_bids():
                 template = BidsComponent(
                     name="t1",
                     path=wildcard_path_t1,
-                    zip_lists={
+                    table={
                         "acq": ["mprage", "mprage"],
                         "subject": ["001", "002"],
                     },
@@ -1546,7 +1557,7 @@ def test_get_lists_from_bids():
                 template = BidsComponent(
                     name="t2",
                     path=wildcard_path_t2,
-                    zip_lists={
+                    table={
                         "subject": ["002"],
                     },
                 )
@@ -1609,7 +1620,7 @@ def test_all_custom_paths(count: int):
             "1": BidsComponent(
                 name="1",
                 path="sub-{subject}/sub-{subject}_{suffix}{extension}",
-                zip_lists={
+                table={
                     "subject": ["0"],
                     "suffix": ["0"],
                     "extension": [".0"],
@@ -1618,7 +1629,7 @@ def test_all_custom_paths(count: int):
             "0": BidsComponent(
                 name="0",
                 path="sub-{subject}/sub-{subject}{extension}",
-                zip_lists={
+                table={
                     "subject": ["0"],
                     "extension": [".0"],
                 },
@@ -1869,16 +1880,18 @@ class TestParseBidsPath:
     @given(component=sb_st.bids_components(max_values=1, restrict_patterns=True))
     def test_splits_wildcards_from_path(self, component: BidsComponent):
         path = component.expand()[0]
-        entities = [BidsEntity.normalize(e).entity for e in component.zip_lists]
+        entities = [BidsEntity.normalize(e) for e in component.zip_lists]
+        wildcards = [BidsEntity.normalize(e).wildcard for e in component.zip_lists]
         tpl_path, matches = _parse_bids_path(path, entities)
-        assert tpl_path.format(**matches) == path
+        assert tpl_path.format(**dict(zip(wildcards, matches))) == path
 
     @given(component=sb_st.bids_components(max_values=1, restrict_patterns=True))
     def test_one_match_found_for_each_entity(self, component: BidsComponent):
         path = component.expand()[0]
-        entities = [BidsEntity.normalize(e).entity for e in component.zip_lists]
+        entities = [BidsEntity.normalize(e) for e in component.zip_lists]
+        wildcards = [BidsEntity.normalize(e).wildcard for e in component.zip_lists]
         _, matches = _parse_bids_path(path, entities)
-        assert set(matches.items()) == {
+        assert set(zip(wildcards, matches)) == {
             (key, val[0]) for key, val in component.zip_lists.items()
         }
 
@@ -1892,10 +1905,10 @@ class TestParseBidsPath:
         self, component: BidsComponent, entity: BidsEntity
     ):
         path = component.expand()[0]
-        entities = [BidsEntity.normalize(e).entity for e in component.zip_lists]
-        assume(entity.entity not in entities)
+        entities = [BidsEntity.normalize(e) for e in component.zip_lists]
+        assume(entity not in entities)
         with pytest.raises(BidsParseError) as err:
-            _parse_bids_path(path, it.chain(entities, [entity.entity]))
+            _parse_bids_path(path, it.chain(entities, [entity]))
         assert err.value.entity == entity
 
 

--- a/snakebids/tests/test_printing.py
+++ b/snakebids/tests/test_printing.py
@@ -25,7 +25,7 @@ def zip_list_parser() -> pp.ParserElement:
     return pp.Suppress("{") + pp.Group(row)[1, ...] + pp.Suppress("}")
 
 
-@given(zip_list=sb_st.zip_lists(max_entities=1, restrict_patterns=True))
+@given(zip_list=sb_st.bids_tables(max_entities=1, restrict_patterns=True))
 def test_ellipses_appears_when_maxwidth_too_short(zip_list: ZipList):
     width = len(format_zip_lists(zip_list, tabstop=0).splitlines()[1])
     parsed = zip_list_parser().parse_string(
@@ -34,13 +34,13 @@ def test_ellipses_appears_when_maxwidth_too_short(zip_list: ZipList):
     assert "ellipse" in parsed[0]
 
 
-@given(zip_list=sb_st.zip_lists(max_entities=1, restrict_patterns=True))
+@given(zip_list=sb_st.bids_tables(max_entities=1, restrict_patterns=True))
 def test_no_ellipses_when_no_max_width(zip_list: ZipList):
     parsed = zip_list_parser().parse_string(format_zip_lists(zip_list, tabstop=0))
     assert "ellipse" not in parsed[0]
 
 
-@given(zip_list=sb_st.zip_lists(max_entities=1, restrict_patterns=True))
+@given(zip_list=sb_st.bids_tables(max_entities=1, restrict_patterns=True))
 def test_no_ellipses_when_max_width_long_enouth(zip_list: ZipList):
     width = len(format_zip_lists(zip_list, tabstop=0).splitlines()[1])
     parsed = zip_list_parser().parse_string(
@@ -50,7 +50,7 @@ def test_no_ellipses_when_max_width_long_enouth(zip_list: ZipList):
 
 
 @given(
-    zip_list=sb_st.zip_lists(
+    zip_list=sb_st.bids_tables(
         max_entities=1, min_values=0, max_values=0, restrict_patterns=True
     )
 )
@@ -63,7 +63,7 @@ def test_no_ellipses_appears_when_ziplist_empty(zip_list: ZipList):
 
 
 @given(
-    zip_list=sb_st.zip_lists(
+    zip_list=sb_st.bids_tables(
         min_values=1, max_values=4, max_entities=4, restrict_patterns=True
     ),
     width=st.integers(min_value=10, max_value=200),
@@ -91,7 +91,7 @@ def test_values_balanced_around_elision_correctly(zip_list: ZipList, width: int)
 
 class TestCorrectNumberOfLinesCreated:
     @given(
-        zip_list=sb_st.zip_lists(
+        zip_list=sb_st.bids_tables(
             min_values=0, max_values=1, max_entities=6, restrict_patterns=True
         ),
     )
@@ -122,7 +122,7 @@ class TestCorrectNumberOfLinesCreated:
 
 class TestIsValidPython:
     @given(
-        zip_list=sb_st.zip_lists(restrict_patterns=True, min_values=0, min_entities=0)
+        zip_list=sb_st.bids_tables(restrict_patterns=True, min_values=0, min_entities=0)
     )
     def test_in_zip_list(self, zip_list: ZipList):
         assert eval(format_zip_lists(zip_list, inf)) == zip_list
@@ -140,7 +140,7 @@ class TestIsValidPython:
 # path and name are allowed to be longer than the width, so finding the zip_list lines
 # would prove more challenging than it's worth
 @given(
-    zip_list=sb_st.zip_lists(max_entities=1, restrict_patterns=True),
+    zip_list=sb_st.bids_tables(max_entities=1, restrict_patterns=True),
     width=st.integers(10, 100),
     tab=st.integers(0, 10),
 )
@@ -158,7 +158,7 @@ def get_indent_length(line: str):
 
 class TestIndentLengthMultipleOfTabStop:
     @given(
-        zip_list=sb_st.zip_lists(restrict_patterns=True, min_values=0),
+        zip_list=sb_st.bids_tables(restrict_patterns=True, min_values=0),
         tabstop=st.integers(1, 10),
     )
     def test_in_zip_list(self, zip_list: ZipList, tabstop: int):

--- a/snakebids/tests/test_tables.py
+++ b/snakebids/tests/test_tables.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import attrs
+import more_itertools as itx
+import pytest
+from hypothesis import assume, given
+
+from snakebids.core._table import BidsTable
+from snakebids.core.datasets import BidsComponent
+from snakebids.tests import strategies as sb_st
+from snakebids.tests.helpers import get_bids_path
+from snakebids.utils.utils import BidsEntity
+
+
+@given(sb_st.bids_tables(min_entities=2))
+def test_zip_lists_must_be_same_length(table: BidsTable):
+    zip_lists = table.to_dict()
+    itx.first(zip_lists.values()).append("foo")
+    with pytest.raises(
+        ValueError, match="each entity must have the same number of values"
+    ):
+        BidsComponent(name="foo", path=get_bids_path(zip_lists), table=zip_lists)
+
+
+class TestEq:
+    @given(sb_st.bids_tables(), sb_st.everything_except(BidsTable))
+    def test_other_types_are_unequal(self, table: BidsTable, other: Any):
+        assert table != other
+
+    @given(sb_st.bids_tables(min_entities=0, min_values=0))
+    def test_copied_object_is_equal(self, table: BidsTable):
+        other = copy.deepcopy(table)
+        assert table == other
+
+    @given(sb_st.bids_tables(min_entities=2, min_values=0))
+    def test_wildcard_order_is_irrelevant(self, table: BidsTable):
+        other = copy.deepcopy(table)
+        reordered = BidsTable(
+            wildcards=reversed(other.wildcards),
+            entries=[tuple(reversed(entry)) for entry in other.entries],
+        )
+        assert table == reordered
+
+    @given(
+        table=sb_st.bids_tables(min_entities=1, min_values=0),
+        wildcard=sb_st.bids_entity(),
+    )
+    def test_wildcards_must_be_the_same(self, table: BidsTable, wildcard: BidsEntity):
+        assume(wildcard.wildcard not in table.wildcards)
+        other = copy.deepcopy(table)
+        reordered = attrs.evolve(other, wildcards=[wildcard, *other.wildcards[1:]])
+        assert table != reordered
+
+    @given(sb_st.bids_tables())
+    def test_mutation_makes_unequal(self, table: BidsTable):
+        cp = copy.deepcopy(table)
+        other = attrs.evolve(
+            cp,
+            entries=[
+                ("0" + "".join(cp.entries[0]), *cp.entries[0][1:]),
+                *cp.entries[1:],
+            ],
+        )
+        assert table != other
+
+    @given(sb_st.bids_tables())
+    def test_extra_entry_makes_unequal(self, table: BidsTable):
+        cp = copy.deepcopy(table)
+        other = attrs.evolve(cp, entries=[cp.entries[0], *cp.entries])
+        assert table != other
+
+    @given(sb_st.bids_tables())
+    def test_missing_entry_makes_unequal(self, table: BidsTable):
+        cp = copy.deepcopy(table)
+        other = attrs.evolve(cp, entries=cp.entries[1:])
+        assert table != other

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -225,15 +225,6 @@ def matches_any(
     return any(match_func(match, item, *args) for match in match_list)
 
 
-class BidsParseError(Exception):
-    """Exception raised for errors encountered in the parsing of Bids paths."""
-
-    def __init__(self, path: str, entity: BidsEntity) -> None:
-        self.path = path
-        self.entity = entity
-        super().__init__(path, entity)
-
-
 class _Documented(Protocol):
     __doc__: str
 


### PR DESCRIPTION
The entry table uses entry-first strides. This will be a much more efficient storage method for future API that makes individual entries more accessible. As much of the core as is currently feasible is rewritten to use entries over zip-lists

The public API is completely unchanged as of now.

Tests for filtering are largely unchanged, although some may be redundant at this point.

