### PR TITLE
Deduplicate wildcards when parsing components

### DIFF
--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -581,7 +581,7 @@ def _get_component(
     for img in matching_files:
         wildcards: list[str] = [
             wildcard
-            for wildcard in component.get("wildcards", [])
+            for wildcard in set(component.get("wildcards", []))
             if wildcard in img.entities
         ]
         _logger.debug("Wildcards %s found entities for %s", wildcards, img.path)


### PR DESCRIPTION
Specifying a wildcard multiple times leads to an unintuitive KeyError. This includes re-specifying a wildcard defined in the config by the developer.

Fix by using a set to deduplicate wildcards before parsing.

