### PR TITLE
Support for conda

### DIFF
--- a/snakebids/io/yaml.py
+++ b/snakebids/io/yaml.py
@@ -2,7 +2,10 @@ import collections
 from pathlib import Path, PosixPath, WindowsPath
 from typing import Any, OrderedDict
 
-from ruamel.yaml import YAML, Dumper
+try:
+    from ruamel.yaml import YAML, Dumper
+except ImportError:
+    from ruamel_yaml import YAML, Dumper
 
 
 def get_yaml_io():

--- a/snakebids/io/yaml.py
+++ b/snakebids/io/yaml.py
@@ -1,6 +1,6 @@
 import collections
 from pathlib import Path, PosixPath, WindowsPath
-from typing import Any, OrderedDict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, OrderedDict
 
 if TYPE_CHECKING:
     from ruamel.yaml import YAML, Dumper

--- a/snakebids/io/yaml.py
+++ b/snakebids/io/yaml.py
@@ -7,8 +7,8 @@ if TYPE_CHECKING:
 else:
     try:
         from ruamel.yaml import YAML, Dumper
-    except ImportError:
-        from ruamel_yaml import YAML, Dumper
+    except ImportError: # pragma: no cover
+        from ruamel_yaml import YAML, Dumper 
 
 
 def get_yaml_io():

--- a/snakebids/io/yaml.py
+++ b/snakebids/io/yaml.py
@@ -1,11 +1,14 @@
 import collections
 from pathlib import Path, PosixPath, WindowsPath
-from typing import Any, OrderedDict
+from typing import Any, OrderedDict, TYPE_CHECKING
 
-try:
+if TYPE_CHECKING:
     from ruamel.yaml import YAML, Dumper
-except ImportError:
-    from ruamel_yaml import YAML, Dumper
+else:
+    try:
+        from ruamel.yaml import YAML, Dumper
+    except ImportError:
+        from ruamel_yaml import YAML, Dumper
 
 
 def get_yaml_io():


### PR DESCRIPTION
## Proposed changes
This PR adds a conditional import for the `ruamel_yaml` dependency. This change is necessary because the conda package manager installs the package as `ruamel_yaml`, while pip installs it as `ruamel`. This discrepancy leads to import errors when working in a conda environment. The conditional import ensures we are agnostic to the installation method, preventing the import error.

Bug Fix:
This PR resolves the import error issue that occurs when the `ruamel.yaml` module is installed via conda. By handling both cases, it ensures the code works in both pip and conda environments.

## Checklist

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published