### PR TITLE
Update tutorial.md to reference pulp version issue

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -24,7 +24,8 @@ $ mkdir snakebids-tutorial
 $ cd snakebids-tutorial
 ```
 
-Check your python version to make sure you have at least version 3.7 or higher:
+Check your python version to make sure you have at least version 3.7 or higher (extra steps
+may be required on older versions like 3.8, e.g. see [here](https://github.com/snakemake/snakemake/issues/2608#issuecomment-2051522989)):
 
 ```console
 $ python --version

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -24,8 +24,8 @@ $ mkdir snakebids-tutorial
 $ cd snakebids-tutorial
 ```
 
-Check your python version to make sure you have at least version 3.7 or higher (extra steps
-may be required on older versions like 3.8, e.g. see [here](https://github.com/snakemake/snakemake/issues/2608#issuecomment-2051522989)):
+Check your python version to make sure you have at least version 3.9 or higher (extra steps
+may be required on older versions like 3.9, e.g. see [here](https://github.com/snakemake/snakemake/issues/2608#issuecomment-2051522989)):
 
 ```console
 $ python --version


### PR DESCRIPTION
Tutorial steps did not work on my Python (3.9) as written, so if continuing to write them for "at least version 3.7" maybe this link to a workaround will help.

## Proposed changes

After getting an error following the tutorial and searching it up, I located a fix in a snakebids issue. Linking to that might be one option to address this error coming up, without interrupting the current nice flow in the doc?

The error is specifically `AttributeError: module 'pulp' has no attribute 'list_solvers'` because `list_solvers` was deprecated in pulp v. 2 and removed in v. 3, and following the tutorial my snakemake install included 3.0.2.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.