### PR TITLE
normalize mixed/absent entities with a configurable “snakenull” label

### DIFF
--- a/docs/bids_app/config_snakenull.md
+++ b/docs/bids_app/config_snakenull.md
@@ -28,17 +28,20 @@ pybids_inputs:
       scope: [session, acquisition]
 ```
 ## Usage
-After calling snakebids.generate_inputs(...), apply:
+include these parameters in generate_inputs():
 ```python
-from snakebids.snakenull import normalize_inputs_with_snakenull
-inputs = snakebids.generate_inputs(bids_dir=..., pybids_inputs=...)
-normalize_inputs_with_snakenull(inputs, config=your_full_config_dict)
+inputs = generate_inputs(
+    bids_dir=config["bids_dir"],
+    pybids_inputs=config["pybids_inputs"],
+    ...
+    snakenull=config.get("snakenull"),
+)
 ```
 This mutates inputs in place so that:
 
-Entities listed in wildcards but entirely absent in your dataset are removed.
+- Entities listed in wildcards but entirely absent in your dataset are removed.
 
-Entities that are present for some files but missing for others are assigned the
+- Entities that are present for some files but missing for others are assigned the
 placeholder label (default snakenull) and included in entities for expansion.
 
 Downstream, your BidsComponent.entities will include e.g.:

--- a/docs/bids_app/config_snakenull.md
+++ b/docs/bids_app/config_snakenull.md
@@ -1,0 +1,51 @@
+# Configuration: Snakenull normalization (optional)
+
+Snakebids can **normalize mixed or absent entities**—cases where some files have an entity
+like `acq` or `ses` but others don’t—by assigning a placeholder label to missing values
+and skipping entities that are entirely absent. This stabilizes wildcard expansion and
+output naming without requiring users to re-label inputs.
+
+This behavior is **off by default** and can be controlled globally or per component.
+
+## Global defaults
+
+```yaml
+snakenull:
+  enabled: false       # default: legacy behavior
+  label: snakenull     # placeholder value for missing entities
+  include_prefix: true # downstream path builders may include "_acq-snakenull_" if true
+  scope: all           # "all" or a list, e.g., ["session", "acquisition"]
+```
+## Per-component override
+```yaml
+pybids_inputs:
+  t1w:
+    filters:
+      suffix: T1w
+      extension: .nii.gz
+    wildcards: [subject, session, acquisition]
+    snakenull:
+      enabled: true
+      scope: [session, acquisition]
+```
+## Usage
+After calling snakebids.generate_inputs(...), apply:
+```python
+from snakebids.snakenull import normalize_inputs_with_snakenull
+inputs = snakebids.generate_inputs(bids_dir=..., pybids_inputs=...)
+normalize_inputs_with_snakenull(inputs, config=your_full_config_dict)
+```
+This mutates inputs in place so that:
+
+Entities listed in wildcards but entirely absent in your dataset are removed.
+
+Entities that are present for some files but missing for others are assigned the
+placeholder label (default snakenull) and included in entities for expansion.
+
+Downstream, your BidsComponent.entities will include e.g.:
+```vbnet
+acquisition: ["MPRAGE", "snakenull"]
+session: ["01", "snakenull"]
+```
+so the expansion space (and target sets) remains stable even as new sessions or
+acquisitions are added later.

--- a/docs/bids_app/config_snakenull.md
+++ b/docs/bids_app/config_snakenull.md
@@ -13,7 +13,6 @@ This behavior is **off by default** and can be controlled globally or per compon
 snakenull:
   enabled: false       # default: legacy behavior
   label: snakenull     # placeholder value for missing entities
-  include_prefix: true # downstream path builders may include "_acq-snakenull_" if true
   scope: all           # "all" or a list, e.g., ["session", "acquisition"]
 ```
 ## Per-component override

--- a/docs/bids_app/overview.md
+++ b/docs/bids_app/overview.md
@@ -4,6 +4,7 @@
 :hidden:
 
 config
+config_snakenull
 workflow
 plugins
 ```

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -398,14 +398,12 @@ pybids_inputs:
 ```
 Code:
 ```python
-import snakebids
-from snakebids.snakenull import normalize_inputs_with_snakenull
-
-inputs = snakebids.generate_inputs(bids_dir=..., pybids_inputs=...)
-normalize_inputs_with_snakenull(inputs, config={
-  "pybids_inputs": {... as above ...},
-  "snakenull": {"enabled": false}  # optional global defaults
-})
+inputs = generate_inputs(
+    bids_dir=config["bids_dir"],
+    pybids_inputs=config["pybids_inputs"],
+    ...
+    snakenull=config.get("snakenull"),
+)
 ```
 Now inputs["t1w"].entities will contain:
 ```vbnet

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -1,3 +1,4 @@
+# pyright: basic, reportPrivateUsage=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false
 """Utilities for converting Snakemake apps to BIDS apps."""
 
 from __future__ import annotations
@@ -14,6 +15,7 @@ from typing import (
     Any,
     Callable,
     Iterable,
+    Iterator,
     Literal,
     Mapping,
     overload,
@@ -586,8 +588,8 @@ def _get_components(
     inputs_config: InputsConfig,
     postfilters: PostFilter,
     limit_to: Iterable[str] | None = None,
-    snakenull_global: dict | None = None,  # <-- NEW (optional)
-):
+    snakenull_global: Mapping[str, Any] | None = None,
+) -> Iterator[BidsComponent]:
     """Generate components based on components config and a bids layout.
 
     Parameters
@@ -628,14 +630,11 @@ def _get_components(
 
         # --- Inline snakenull normalization (mutates comp in place) ---
         if normalize_inputs_with_snakenull is not None:
-            # Build a tiny view of config for this single component
-            cfg_for_this = {
-                "pybids_inputs": {name: inputs_config[name]},
-            }
-            if snakenull_global:
-                cfg_for_this["snakenull"] = snakenull_global
-
-            # Normalizer is a no-op if not enabled globally or per-component
+            cfg_for_this: dict[str, Any] = {}
+            cfg_for_this["pybids_inputs"] = {name: inputs_config[name]}
+            if snakenull_global is not None:
+                # make it a real dict so downstream code that expects a dict is happy
+                cfg_for_this["snakenull"] = dict(snakenull_global)
             normalize_inputs_with_snakenull({name: comp}, config=cfg_for_this)
         # ----------------------------------------------------------------
 

--- a/snakebids/snakenull.py
+++ b/snakebids/snakenull.py
@@ -1,3 +1,4 @@
+# pyright: basic, reportPrivateUsage=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false
 """
 Post-processing utilities to normalize mixed/absent entities in Snakebids inputs.
 
@@ -10,7 +11,7 @@ internal hooks.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, MutableMapping
+from typing import Any, Iterable, Mapping, MutableMapping, cast
 
 
 @dataclass(frozen=True)
@@ -126,13 +127,13 @@ def _set_component_entities(component, entities: Mapping[str, list[str]]) -> Non
     # wildcards
     wildcards = {k: "{" + k + "}" for k in entities}
     if hasattr(component, "wildcards"):
-        component.wildcards = wildcards
+        cast(Any, component).wildcards = wildcards
     elif isinstance(component, MutableMapping):
         component["wildcards"] = wildcards
     # optional flags for downstream path builders
     if hasattr(component, "__dict__"):
-        component.snakenull_label = None
-        component.snakenull_include_prefix = True
+        cast(Any, component).snakenull_label = None
+        cast(Any, component).snakenull_include_prefix = True
     if isinstance(component, MutableMapping):
         component["snakenull_label"] = None
         component["snakenull_include_prefix"] = True
@@ -198,8 +199,8 @@ def normalize_inputs_with_snakenull(
 
         # annotate component with snakenull rendering preferences if helpful later
         if hasattr(comp, "__dict__"):
-            comp.snakenull_label = s_cfg.label
-            comp.snakenull_include_prefix = s_cfg.include_prefix
+            cast(Any, comp).snakenull_label = s_cfg.label
+            cast(Any, comp).snakenull_include_prefix = s_cfg.include_prefix
         if isinstance(comp, MutableMapping):
             comp["snakenull_label"] = s_cfg.label
             comp["snakenull_include_prefix"] = s_cfg.include_prefix

--- a/snakebids/snakenull.py
+++ b/snakebids/snakenull.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, MutableMapping, Any
+
+"""
+snakenull.py: Post-processing utilities for normalizing mixed/absent entities
+in Snakebids inputs using a configurable placeholder label (default: "snakenull").
+
+This module operates on public objects returned by snakebids.generate_inputs()
+and does not require internal hooks. You can later integrate it deeper if desired.
+"""
+
+@dataclass(frozen=True)
+class SnakenullConfig:
+    enabled: bool = False
+    label: str = "snakenull"
+    include_prefix: bool = True   # downstream path builders may use this
+    scope: Iterable[str] | str = "all"  # "all" or iterable of entity names
+
+def _in_scope(ent: str, scope: Iterable[str] | str) -> bool:
+    return scope == "all" or ent in set(scope)
+
+def _merge_cfg(global_cfg: Mapping[str, Any] | None,
+               local_cfg: Mapping[str, Any] | None) -> SnakenullConfig:
+    base = {"enabled": False, "label": "snakenull", "include_prefix": True, "scope": "all"}
+    if global_cfg:
+        base.update(global_cfg)
+    if local_cfg:
+        base.update(local_cfg)
+    return SnakenullConfig(**base)
+
+def _collect_present_values(component) -> tuple[Dict[str, set[str]], Dict[str, bool], list[str]]:
+    """
+    Work against both attribute- and mapping-style components.
+    We infer:
+      - wildcard list
+      - matched files
+      - each file's .entities mapping (PyBIDS-style)
+    """
+    # Wildcards list
+    wc_list: list[str] = []
+    if hasattr(component, "requested_wildcards"):
+        wc_list = list(getattr(component, "requested_wildcards"))
+    elif hasattr(component, "wildcards") and isinstance(component.wildcards, Mapping):
+        wc_list = list(component.wildcards.keys())
+    elif isinstance(component, Mapping) and "wildcards" in component:
+        wc_list = list(component["wildcards"].keys())
+
+    present_values: Dict[str, set[str]] = {w: set() for w in wc_list}
+    has_missing: Dict[str, bool] = {w: False for w in wc_list}
+
+    # Matched files
+    files = None
+    for attr in ("matched_files", "files", "items", "records"):
+        if hasattr(component, attr):
+            files = getattr(component, attr)
+            break
+    if files is None and isinstance(component, Mapping):
+        for key in ("matched_files", "files", "items", "records"):
+            if key in component:
+                files = component[key]
+                break
+    files = files or []
+
+    for rec in files:
+        ents = {}
+        if hasattr(rec, "entities"):
+            ents = getattr(rec, "entities") or {}
+        elif isinstance(rec, Mapping) and "entities" in rec:
+            ents = rec["entities"] or {}
+        for ent in wc_list:
+            if ent in ents and ents[ent] not in (None, ""):
+                present_values[ent].add(str(ents[ent]))
+            else:
+                has_missing[ent] = True
+
+    return present_values, has_missing, wc_list
+
+def _set_component_entities(component, entities: Mapping[str, list[str]]) -> None:
+    """Write back normalized entities and rebuild wildcards if needed."""
+    # entities
+    if hasattr(component, "entities"):
+        component.entities = dict(entities)
+    elif isinstance(component, MutableMapping):
+        component["entities"] = dict(entities)
+    # wildcards
+    wildcards = {k: "{" + k + "}" for k in entities.keys()}
+    if hasattr(component, "wildcards"):
+        component.wildcards = wildcards
+    elif isinstance(component, MutableMapping):
+        component["wildcards"] = wildcards
+    # optional flags for downstream path builders
+    if hasattr(component, "__dict__"):
+        setattr(component, "_snakenull_label", None)
+        setattr(component, "_snakenull_include_prefix", True)
+    if isinstance(component, MutableMapping):
+        component["_snakenull_label"] = None
+        component["_snakenull_include_prefix"] = True
+
+def normalize_inputs_with_snakenull(
+    inputs: Mapping[str, Any],
+    *,
+    config: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    """
+    Post-process the result of snakebids.generate_inputs() to:
+      1) Skip entities listed in wildcards that are entirely absent in the dataset
+      2) For entities present in some files but missing in others, insert a placeholder
+         value (default: "snakenull")
+
+    Parameters
+    ----------
+    inputs : Mapping[str, Any]
+        The object returned by snakebids.generate_inputs(), mapping
+        component name -> component.
+    config : Mapping[str, Any], optional
+        Top-level Snakebids config dict. Read from:
+           config["snakenull"] (global defaults)
+           config["pybids_inputs"][<component>]["snakenull"] (per-component override)
+
+    Returns
+    -------
+    Mapping[str, Any]
+        The same mapping (mutated in place).
+    """
+    pybids_inputs = {}
+    if config and isinstance(config.get("pybids_inputs"), Mapping):
+        pybids_inputs = config["pybids_inputs"]
+    global_cfg = {}
+    if config and isinstance(config.get("snakenull"), Mapping):
+        global_cfg = config["snakenull"]
+
+    for cname, comp in inputs.items():
+        local_cfg = {}
+        if isinstance(pybids_inputs.get(cname), Mapping):
+            local_cfg = pybids_inputs[cname].get("snakenull", {}) or {}
+        s_cfg = _merge_cfg(global_cfg, local_cfg)
+
+        if not s_cfg.enabled:
+            # No-op; preserve legacy behavior
+            continue
+
+        present_values, has_missing, wc_list = _collect_present_values(comp)
+
+        normalized: Dict[str, list[str]] = {}
+        for ent in wc_list:
+            vals = present_values.get(ent, set())
+            if not vals:
+                # Entirely absent: drop this entity
+                continue
+            if has_missing.get(ent, False) and _in_scope(ent, s_cfg.scope):
+                vals = set(vals) | {s_cfg.label}
+            normalized[ent] = sorted(vals)
+
+        _set_component_entities(comp, normalized)
+
+        # annotate component with snakenull rendering preferences if helpful later
+        if hasattr(comp, "__dict__"):
+            setattr(comp, "_snakenull_label", s_cfg.label)
+            setattr(comp, "_snakenull_include_prefix", s_cfg.include_prefix)
+        if isinstance(comp, MutableMapping):
+            comp["_snakenull_label"] = s_cfg.label
+            comp["_snakenull_include_prefix"] = s_cfg.include_prefix
+
+    return inputs

--- a/snakebids/snakenull.py
+++ b/snakebids/snakenull.py
@@ -139,9 +139,12 @@ def _collect_present_values(
 def _set_component_entities(component: Any, entities: Mapping[str, list[str]]) -> None:
     """Expose normalized entity domains without breaking frozen components.
 
-    - If the component is a MutableMapping, write into its keys ('entities', 'wildcards').
-    - Otherwise, *best effort* set attributes, but swallow AttributeError from frozen attrs.
-    - Always try to stash under a side attribute 'snakenull_entities' for consumers that
+    - If the component is a MutableMapping, write into its keys
+    ('entities', 'wildcards').
+    - Otherwise, *best effort* set attributes, but swallow AttributeError
+    from frozen attrs.
+    - Always try to stash under a side attribute 'snakenull_entities' for
+    consumers that
       choose to read it explicitly.
     """
     # Prefer writing into mapping-like components (safe, no __setattr__)

--- a/snakebids/tests/test_snakenull.py
+++ b/snakebids/tests/test_snakenull.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+import pytest
+from snakebids.snakenull import normalize_inputs_with_snakenull
+
+class DummyRec:
+    def __init__(self, entities):
+        self.entities = entities
+
+class DummyComponent:
+    def __init__(self, requested_wildcards, records):
+        self.requested_wildcards = list(requested_wildcards)
+        self.matched_files = [DummyRec(e) for e in records]
+        self.entities = {}
+        self.wildcards = {}
+
+def _entities(component):
+    return component.entities
+
+def test_snakenull_disabled_is_noop():
+    inputs = {
+        "t1w": DummyComponent(
+            ["subject", "session", "acquisition"],
+            [
+                {"subject": "01", "session": "01", "acquisition": "MPRAGE"},
+                {"subject": "02"},  # missing session & acquisition
+            ],
+        )
+    }
+    cfg = {
+        "pybids_inputs": {"t1w": {"wildcards": ["subject", "session", "acquisition"]}},
+        "snakenull": {"enabled": False},
+    }
+    normalize_inputs_with_snakenull(inputs, config=cfg)
+    ents = _entities(inputs["t1w"])
+    # No processing happened; in particular, no 'snakenull' is injected
+    flat = {v for vals in ents.values() for v in vals} if ents else set()
+    assert "snakenull" not in flat
+
+def test_snakenull_enables_mixed_entity_normalization():
+    inputs = {
+        "t1w": DummyComponent(
+            ["subject", "session", "acquisition"],
+            [
+                {"subject": "01", "session": "01", "acquisition": "MPRAGE"},
+                {"subject": "02"},  # missing session & acquisition
+            ],
+        )
+    }
+    cfg = {
+        "pybids_inputs": {
+            "t1w": {
+                "wildcards": ["subject", "session", "acquisition"],
+                "snakenull": {"enabled": True, "scope": ["session", "acquisition"]},
+            }
+        }
+    }
+    normalize_inputs_with_snakenull(inputs, config=cfg)
+    ents = _entities(inputs["t1w"])
+    assert "acquisition" in ents
+    assert set(ents["acquisition"]) == {"MPRAGE", "snakenull"}
+    assert "session" in ents
+    assert set(ents["session"]) == {"01", "snakenull"}
+
+def test_snakenull_skips_completely_absent_entities():
+    inputs = {
+        "t1w": DummyComponent(
+            ["subject", "session", "acquisition", "run"],
+            [
+                {"subject": "01", "session": "01", "acquisition": "MPRAGE"},
+                {"subject": "02"},  # still no 'run' anywhere
+            ],
+        )
+    }
+    cfg = {
+        "pybids_inputs": {
+            "t1w": {
+                "wildcards": ["subject", "session", "acquisition", "run"],
+                "snakenull": {"enabled": True, "scope": "all"},
+            }
+        }
+    }
+    normalize_inputs_with_snakenull(inputs, config=cfg)
+    ents = _entities(inputs["t1w"])
+    assert "run" not in ents

--- a/snakebids/tests/test_snakenull.py
+++ b/snakebids/tests/test_snakenull.py
@@ -1,10 +1,10 @@
-from types import SimpleNamespace
-import pytest
 from snakebids.snakenull import normalize_inputs_with_snakenull
+
 
 class DummyRec:
     def __init__(self, entities):
         self.entities = entities
+
 
 class DummyComponent:
     def __init__(self, requested_wildcards, records):
@@ -13,8 +13,10 @@ class DummyComponent:
         self.entities = {}
         self.wildcards = {}
 
+
 def _entities(component):
     return component.entities
+
 
 def test_snakenull_disabled_is_noop():
     inputs = {
@@ -35,6 +37,7 @@ def test_snakenull_disabled_is_noop():
     # No processing happened; in particular, no 'snakenull' is injected
     flat = {v for vals in ents.values() for v in vals} if ents else set()
     assert "snakenull" not in flat
+
 
 def test_snakenull_enables_mixed_entity_normalization():
     inputs = {
@@ -60,6 +63,7 @@ def test_snakenull_enables_mixed_entity_normalization():
     assert set(ents["acquisition"]) == {"MPRAGE", "snakenull"}
     assert "session" in ents
     assert set(ents["session"]) == {"01", "snakenull"}
+
 
 def test_snakenull_skips_completely_absent_entities():
     inputs = {

--- a/snakebids/tests/test_snakenull.py
+++ b/snakebids/tests/test_snakenull.py
@@ -1,25 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
 from snakebids.snakenull import normalize_inputs_with_snakenull
 
 
 class DummyRec:
-    def __init__(self, entities):
-        self.entities = entities
+    def __init__(self, entities: Mapping[str, str]) -> None:
+        self.entities: Mapping[str, str] = entities
 
 
 class DummyComponent:
-    def __init__(self, requested_wildcards, records):
-        self.requested_wildcards = list(requested_wildcards)
-        self.matched_files = [DummyRec(e) for e in records]
-        self.entities = {}
-        self.wildcards = {}
+    def __init__(
+        self, requested_wildcards: Sequence[str], records: Sequence[Mapping[str, str]]
+    ) -> None:
+        self.requested_wildcards: list[str] = list(requested_wildcards)
+        self.matched_files: list[DummyRec] = [DummyRec(e) for e in records]
+        # Filled by normalize_inputs_with_snakenull; mapping entity -> list of values
+        self.entities: dict[str, list[str]] = {}
+        # Mapping entity -> "{entity}" placeholder
+        self.wildcards: dict[str, str] = {}
 
 
-def _entities(component):
+def _entities(component: DummyComponent) -> dict[str, list[str]]:
     return component.entities
 
 
-def test_snakenull_disabled_is_noop():
-    inputs = {
+def test_snakenull_disabled_is_noop() -> None:
+    inputs: dict[str, DummyComponent] = {
         "t1w": DummyComponent(
             ["subject", "session", "acquisition"],
             [
@@ -28,19 +36,19 @@ def test_snakenull_disabled_is_noop():
             ],
         )
     }
-    cfg = {
+    cfg: dict[str, Any] = {
         "pybids_inputs": {"t1w": {"wildcards": ["subject", "session", "acquisition"]}},
         "snakenull": {"enabled": False},
     }
     normalize_inputs_with_snakenull(inputs, config=cfg)
     ents = _entities(inputs["t1w"])
     # No processing happened; in particular, no 'snakenull' is injected
-    flat = {v for vals in ents.values() for v in vals} if ents else set()
+    flat: set[str] = {v for vals in ents.values() for v in vals} if ents else set()
     assert "snakenull" not in flat
 
 
-def test_snakenull_enables_mixed_entity_normalization():
-    inputs = {
+def test_snakenull_enables_mixed_entity_normalization() -> None:
+    inputs: dict[str, DummyComponent] = {
         "t1w": DummyComponent(
             ["subject", "session", "acquisition"],
             [
@@ -49,7 +57,7 @@ def test_snakenull_enables_mixed_entity_normalization():
             ],
         )
     }
-    cfg = {
+    cfg: dict[str, Any] = {
         "pybids_inputs": {
             "t1w": {
                 "wildcards": ["subject", "session", "acquisition"],
@@ -65,8 +73,8 @@ def test_snakenull_enables_mixed_entity_normalization():
     assert set(ents["session"]) == {"01", "snakenull"}
 
 
-def test_snakenull_skips_completely_absent_entities():
-    inputs = {
+def test_snakenull_skips_completely_absent_entities() -> None:
+    inputs: dict[str, DummyComponent] = {
         "t1w": DummyComponent(
             ["subject", "session", "acquisition", "run"],
             [
@@ -75,7 +83,7 @@ def test_snakenull_skips_completely_absent_entities():
             ],
         )
     }
-    cfg = {
+    cfg: dict[str, Any] = {
         "pybids_inputs": {
             "t1w": {
                 "wildcards": ["subject", "session", "acquisition", "run"],


### PR DESCRIPTION
## Proposed changes

Adds optional normalization so that when a component lists an entity in wildcards but some matched files lack that entity, missing values are relabeled to `snakenull` (configurable). If an entity listed in wildcards is entirely absent across the dataset, that entity is skipped for that component. Path construction can include or omit the {key}-snakenull segment via a flag. Default remains the current behavior (feature disabled). This integrates cleanly with `generate_inputs()`/`BidsComponent` (per Snakebids docs), and preserves expand/wildcards semantics users rely on. 

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests (pytest -q snakebids/tests/test_snakenull.py;  poe quality; still working through other quality checks)
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.