### PR TITLE
Add uv build option for template creation

### DIFF
--- a/containers/test-template/Dockerfile
+++ b/containers/test-template/Dockerfile
@@ -5,10 +5,10 @@ FROM python:${PYTHON_VERSION}-slim
 RUN apt-get update && apt-get install -y gcc git && \
     rm -rf /var/lib/apt/lists/* && \
     git config --global --add safe.directory /src && \
-    python -m pip install pipx && \
-    pipx install poetry && \
-    pipx install hatch && \
-    pipx install pdm && \
+    python -m pip install uv && \
+    uv pip install poetry && \
+    uv pip install hatch && \
+    uv pip install pdm && \
     mkdir prebuild && \
     cd prebuild && \
     pip wheel snakebids && \

--- a/src/snakebids/project_template/copier.yaml
+++ b/src/snakebids/project_template/copier.yaml
@@ -109,6 +109,7 @@ _message_after_copy: >
     $ hatch env create
   {%- elif build_system == "uv" %}
     $ uv sync
+    $ source .venv/bin/activate
     $ uv pip install .
   {%- else %}
     $ python -m venv .venv

--- a/src/snakebids/project_template/copier.yaml
+++ b/src/snakebids/project_template/copier.yaml
@@ -47,6 +47,7 @@ build_system:
     - poetry
     - hatch
     - flit
+    - uv
 
 # Flit and setuptools requires specifying license via Trove classifiers; too
 # complicated to get via interactive prompt
@@ -106,6 +107,9 @@ _message_after_copy: >
     $ poetry install
   {%- elif build_system == "hatch" %}
     $ hatch env create
+  {%- elif build_system == "uv" %}
+    $ uv sync
+    $ uv pip install .
   {%- else %}
     $ python -m venv .venv
     $ source .venv/bin/activate
@@ -120,6 +124,9 @@ _message_after_copy: >
 
   {%- elif build_system == "hatch" %}
     $ hatch env run -- {{ test_run_cmd }}
+
+  {%- elif build_system == "uv" %}
+    $ uv run {{ test_run_cmd }}
 
   {%- else %}
     $ {{ test_run_cmd }}

--- a/src/snakebids/project_template/{% if build_system != 'poetry' %}pyproject.toml{% endif %}.jinja
+++ b/src/snakebids/project_template/{% if build_system != 'poetry' %}pyproject.toml{% endif %}.jinja
@@ -48,6 +48,9 @@ build-backend = "flit_core.buildapi"
 {%- elif build_system == "hatch" -%}
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+{%- elif build_system == "uv" -%}
+requires = ["uv_build>=0.9.9,<0.10.0"]
+build-backend = "uv_build"
 {%- else -%}
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/src/snakebids/project_template/{% if build_system != 'poetry' %}pyproject.toml{% endif %}.jinja
+++ b/src/snakebids/project_template/{% if build_system != 'poetry' %}pyproject.toml{% endif %}.jinja
@@ -56,6 +56,10 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 {%- endif %}
 
+[tool.uv.build-backend]
+module-name = "{{ name_slug }}"
+module-root = ""
+
 {%- if snakebids_is_direct_reference == "True" and build_system == "hatch" %}
 
 [tool.hatch.metadata]

--- a/src/snakebids/project_template/{% if build_system != 'poetry' %}pyproject.toml{% endif %}.jinja
+++ b/src/snakebids/project_template/{% if build_system != 'poetry' %}pyproject.toml{% endif %}.jinja
@@ -56,9 +56,11 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 {%- endif %}
 
+{% if build_system == "uv" -%}
 [tool.uv.build-backend]
 module-name = "{{ name_slug }}"
 module-root = ""
+{%- endif %}
 
 {%- if snakebids_is_direct_reference == "True" and build_system == "hatch" %}
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -29,8 +29,8 @@ else:
 import snakebids
 from tests.helpers import allow_function_scoped, needs_docker
 
-BuildBackend = Literal["poetry", "hatch", "flit", "setuptools"]
-BUILD_BACKENDS: Final[list[BuildBackend]] = ["poetry", "hatch", "flit", "setuptools"]
+BuildBackend = Literal["poetry", "hatch", "flit", "setuptools", "uv"]
+BUILD_BACKENDS: Final[list[BuildBackend]] = ["poetry", "hatch", "flit", "setuptools", "uv"]
 
 
 class DataFields(TypedDict):
@@ -199,6 +199,7 @@ def test_invalid_app_name_raises_error(name: str, tmp_path: Path):
         ("hatch", "hatchling.build"),
         ("flit", "flit_core.buildapi"),
         ("setuptools", "setuptools.build_meta"),
+        ("uv", "uv_build")
     ],
 )
 def test_correct_build_system_used(
@@ -296,6 +297,7 @@ def test_pyproject_correctly_formatted(
         ("poetry", "poetry"),
         ("hatch", "hatch"),
         ("flit", "setuptools"),
+        ("uv", "uv")
     ],
 )
 def test_template_dry_runs_successfully(


### PR DESCRIPTION
## Proposed changes

This PR adds support for the uv package manager as an option when creating a Snakebids app using the snakebids create command.

Key changes include:
- Conditional logic in the Jinja template files to configure the pyproject.toml and install instructions for uv
- Logic alignment with uv_build for backend config (i.e., uses uv_build as the build backend for uv)
- Updated CLI validation logic to recognize uv as a valid option

This resolves support request/feature expansion for modern Python packaging tools and enables compatibility with uv. 

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.