### PR TITLE
Imprecisions in `bids()` testing

### DIFF
--- a/src/snakebids/paths/_factory.py
+++ b/src/snakebids/paths/_factory.py
@@ -33,9 +33,10 @@ class BidsFunction(Protocol):
 
 
 def _handle_subses_dir(
-    root: str | Path | None = None,
-    *,
+    root: str | Path | None,
     spec: BidsPathSpec,
+    /,
+    *,
     sub_dir_default: bool,
     ses_dir_default: bool,
     sub_dir: str | bool | None,
@@ -173,7 +174,7 @@ def bids_factory(spec: BidsPathSpec, *, _implicit: bool = False) -> BidsFunction
         if (
             result := _handle_subses_dir(
                 root,
-                spec=spec,
+                spec,
                 sub_dir_default=subject_dir_default,
                 ses_dir_default=session_dir_default,
                 sub_dir=entities.pop("include_subject_dir", None),

--- a/tests/test_paths/test_bids.py
+++ b/tests/test_paths/test_bids.py
@@ -51,7 +51,7 @@ def make_bids_testsuite(spec: BidsPathSpec):
         )
         custom_ents = (
             _values()
-            .map(BidsEntity)
+            .map(BidsEntity.from_tag)
             .filter(
                 lambda s: str(s)
                 not in (


### PR DESCRIPTION
Fix imprecise test inputs to one of the bids testing functions. Change the signature of a private utility function within path._factory that was preventing the use of `spec` as an entity (not an official entity, but consistent with naming rules).
