### PR TITLE
Refactor generate_inputs filtering tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,6 @@ docs = [
 [project.scripts]
 snakebids = "snakebids.admin:main"
 
-[tool.poe]
-executor.type = "uv"
-
 [tool.poe.tasks]
 setup = "pre-commit install"
 sort.cmd = "ruff check --fix --select I001 $path"

--- a/src/snakebids/core/_querying.py
+++ b/src/snakebids/core/_querying.py
@@ -17,6 +17,8 @@ from snakebids.types import FilterMap, FilterValue, InputConfig
 
 CompiledFilter: TypeAlias = "Mapping[str, Sequence[str | Query]]"
 
+_VALID_FILTER_METHODS = frozenset(("get", "match", "search"))
+
 
 class PostFilter:
     """Filters to apply after indexing, typically derived from the CLI.
@@ -28,6 +30,13 @@ class PostFilter:
         self.inclusions: dict[str, Sequence[str] | str] = {}
         self.exclusions: dict[str, Sequence[str] | str] = {}
 
+    def __eq__(self, other: object):
+        if not isinstance(other, self.__class__):
+            return False
+        return (
+            self.inclusions == other.inclusions and self.exclusions == other.exclusions
+        )
+
     def add_filter(
         self,
         key: str,
@@ -37,8 +46,7 @@ class PostFilter:
         """Add entity filter based on inclusion or exclusion criteria.
 
         Converts a list of values to include or exclude into Pybids compatible filters.
-        Exclusion filters are appropriately formatted as regex. Raises an exception if
-        both include and exclude are stipulated.
+        Exclusion filters are appropriately formatted as regex.
 
         PostFilter is modified in-place.
 
@@ -52,27 +60,28 @@ class PostFilter:
         exclusions
             Values to exclude, only values not found in this list will be included, by
             default ``None``
-
-        Raises
-        ------
-        ValueError
-            Raised if both include and exclude values are stipulated.
         """
         if inclusions is not None:
             self.inclusions[key] = list(itx.always_iterable(inclusions))
-        if exclusions is not None:
-            self.exclusions[key] = self._format_exclusions(exclusions)
+        if exclusions is not None and (
+            (formatted := self._format_exclusions(exclusions)) is not None
+        ):
+            self.exclusions[key] = formatted
 
     def _format_exclusions(self, exclusions: Iterable[str] | str):
+        hit = None
         # if multiple items to exclude, combine with with item1|item2|...
         exclude_string = "|".join(
-            re.escape(label) for label in itx.always_iterable(exclusions)
+            hit := re.escape(label) for label in itx.always_iterable(exclusions)
         )
+        if hit is None:
+            return None
         # regex to exclude subjects
-        return [f"^((?!({exclude_string})$).*)$"]
+        # ^ (NOT: (item1|item2|...)$) ANYTHING...
+        return [f"^(?!(?:{exclude_string})$).*"]
 
 
-@attrs.define(slots=False)
+@attrs.define
 class UnifiedFilter:
     """Manages component level and post filters."""
 
@@ -94,7 +103,7 @@ class UnifiedFilter:
     @classmethod
     def from_filter_dict(
         cls,
-        filters: Mapping[str, str | bool | Sequence[str | bool]],
+        filters: FilterMap,
         postfilter: PostFilter | None = None,
     ) -> Self:
         """Patch together a UnifiedFilter based on a basic filter dict.
@@ -246,6 +255,7 @@ def get_matching_files(
         raise PybidsError(msg) from err
 
     if search is not None:
+        # intersection preserving order
         return [p for p in get if p in search]
     return get
 
@@ -338,11 +348,11 @@ def _compile_filters(filters: FilterMap, *, with_regex: bool) -> CompiledFilter:
             filt = raw_filter
             filt_type = "get"
         else:
-            if filt_type not in {"match", "search", "get"}:
+            if filt_type not in _VALID_FILTER_METHODS:
                 raise _InvalidKeyError(key, raw_filter)
             if TYPE_CHECKING:
                 assert isinstance(raw_filter, dict)
-            filt = cast("str | bool | Sequence[str | bool]", raw_filter[filt_type])
+            filt = raw_filter[filt_type]  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
         # these two must not be simultaneously true or false
         if with_regex == (filt_type == "get"):

--- a/src/snakebids/core/input_generation.py
+++ b/src/snakebids/core/input_generation.py
@@ -681,9 +681,8 @@ def _parse_custom_path(
     """Glob wildcards from a custom path and apply filters.
 
     This replicates pybids path globbing for any custom path. Input path should have
-    wildcards in braces as in "path/of/{wildcard_1}/{wildcard_2}_{wildcard_3}" Output
-    will be arranged into a zip list of matches, list of matches, and Snakemake wildcard
-    for each wildcard.
+    wildcards in braces as in "path/of/{wildcard_1}/{wildcard_2}_{wildcard_3}". Returns
+    a ZipList of matches.
 
     Note that, currently, this will get confused if wildcard content matches
     non-wildcard content. For example, considering the path template above, the example
@@ -693,14 +692,12 @@ def _parse_custom_path(
     ----------
     input_path : str
         Path to be globbed
-    regex_search : bool
-        If True, use regex matching for filtering rather than simple equality
-    **filters : str or list of str
-        Values to keep. Each argument is the name of the entity to search
+    filters : UnifiedFilter
+        Filters to be applied when selecting path templates.
 
     Returns
     -------
-    input_zip_list, input_list, input_wildcards
+    ZipList
     """
     if not (wildcards := glob_wildcards(input_path)):
         _logger.warning("No wildcards defined in %s", input_path)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,7 +21,7 @@ from hypothesis import HealthCheck, example, settings
 from typing_extensions import ParamSpec
 
 from snakebids import bids_factory
-from snakebids.core.datasets import BidsDataset
+from snakebids.core.datasets import BidsComponent, BidsDataset
 from snakebids.core.input_generation import generate_inputs
 from snakebids.paths import specs
 from snakebids.types import InputsConfig, ZipList, ZipListLike
@@ -31,6 +31,13 @@ from snakebids.utils.utils import BidsEntity
 _T = TypeVar("_T")
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _P = ParamSpec("_P")
+
+
+def component_via_product(**entities: list[str] | str):
+    zip_list = get_zip_list(
+        entities, it.product(*map(itx.always_iterable, entities.values()))
+    )
+    return BidsComponent(zip_lists=zip_list, path=get_bids_path(entities), name="")
 
 
 def get_zip_list(

--- a/tests/test_generate_inputs.py
+++ b/tests/test_generate_inputs.py
@@ -1836,7 +1836,7 @@ class TestParticipantFiltering:
             comp["filters"]["subject"] = subject
         reindexed = generate_inputs(
             root,
-            create_snakebids_config(rooted),
+            config,
             **self.get_filter_params(mode, participant_filter),
         )
         assert reindexed == rooted

--- a/tests/test_querying.py
+++ b/tests/test_querying.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import itertools as it
+import re
+import string
+from collections.abc import Sequence
+from typing import Any, cast
+
+import more_itertools as itx
+import pytest
+from bids.layout import Query
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from snakebids.core._querying import (
+    _VALID_FILTER_METHODS,
+    PostFilter,
+    UnifiedFilter,
+    _compile_filters,
+    _InvalidKeyError,
+    _TooFewKeysError,
+    _TooManyKeysError,
+    get_matching_files,
+)
+from snakebids.exceptions import PybidsError
+from snakebids.types import FilterMap, InputConfig
+from tests import strategies as sb_st
+
+
+def _filters(*, min_size: int = 0):
+    return st.dictionaries(
+        sb_st.bids_entity().map(str), sb_st.bids_value(), min_size=min_size
+    )
+
+
+_mixed_filters: st.SearchStrategy[dict[str, str | list[str] | dict[str, str]]] = (
+    st.dictionaries(
+        sb_st.bids_entity().map(str),
+        (
+            st.text()
+            | st.lists(st.text(), min_size=1)
+            | st.sampled_from(tuple(_VALID_FILTER_METHODS)).map(lambda m: {m: ""})
+        ),
+        max_size=6,
+    )
+)
+
+
+class TestPostFilter:
+    def test_postfilter_initialized_empty(self):
+        pf = PostFilter()
+        assert pf.inclusions == {}
+        assert pf.exclusions == {}
+
+    @given(other=sb_st.everything_except(PostFilter))
+    def test_postfilter_not_equal_to_other_types(self, other: Any):
+        assert PostFilter() != other
+
+    @given(
+        inclusions=st.dictionaries(st.text(), st.text() | st.lists(st.text())),
+        exclusions=st.dictionaries(st.text(), st.text() | st.lists(st.text())),
+    )
+    def test_postfilter_equal_to_self(
+        self,
+        inclusions: dict[str, str | list[str]],
+        exclusions: dict[str, str | list[str]],
+    ):
+        pf1 = PostFilter()
+        pf2 = PostFilter()
+        for pf in (pf1, pf2):
+            for key, val in inclusions.items():
+                pf.add_filter(key, inclusions=val, exclusions=None)
+            for key, val in exclusions.items():
+                pf.add_filter(key, inclusions=None, exclusions=val)
+        assert pf1 == pf2
+
+    @pytest.mark.parametrize("filter_type", ["inclusions", "exclusions"])
+    @given(
+        first=st.dictionaries(st.text(), st.text() | st.lists(st.text(), min_size=1)),
+        second=st.dictionaries(st.text(), st.text() | st.lists(st.text(), min_size=1)),
+    )
+    def test_postfilter_not_equal_when_filters_different(
+        self,
+        first: dict[str, str | list[str]],
+        second: dict[str, str | list[str]],
+        filter_type: str,
+    ):
+        assume(first != second)
+        pfs: list[PostFilter] = []
+        for inst in (first, second):
+            pfs.append(PostFilter())
+            for key, val in inst.items():
+                filters: dict[str, str | list[str] | None] = {
+                    "inclusions": None,
+                    "exclusions": None,
+                }
+                filters[filter_type] = val
+                pfs[-1].add_filter(key, **filters)
+
+        assert pfs[0] != pfs[1]
+
+    @given(key=st.text(), val=st.text() | st.iterables(st.text()))
+    def test_add_filter_turns_inclusions_into_list(
+        self, key: str, val: list[str] | str
+    ):
+        pf = PostFilter()
+        pf.add_filter(key, val, None)
+        assert isinstance(pf.inclusions[key], list)
+
+    @given(key=st.text(), val=st.text() | st.lists(st.text()))
+    def test_add_filter_copies_inclusions_without_modification(
+        self, key: str, val: list[str] | str
+    ):
+        pf = PostFilter()
+        pf.add_filter(key, itx.always_iterable(val), None)
+        if isinstance(val, str):
+            assert pf.inclusions[key] == [val]
+        else:
+            assert pf.inclusions[key] == list(val)
+
+    @given(key=st.text(), vals=st.text() | st.lists(st.text(), min_size=1))
+    def test_add_filter_turns_exclusions_into_regex(self, key: str, vals: list[str]):
+        pf = PostFilter()
+        pf.add_filter(key, None, vals)
+        # exclusions are stored as a list containing a regex string
+        assert key in pf.exclusions
+        excl = pf.exclusions[key]
+        assert isinstance(excl, list)
+        assert len(excl) == 1
+        assert isinstance(excl[0], str)
+
+    def test_empty_list_of_exclusions_treated_as_none(self):
+        pf = PostFilter()
+        pf.add_filter("", None, iter([]))
+        assert "" not in pf.exclusions
+
+    @given(
+        exclusion=st.text() | st.lists(st.text(), min_size=1),
+        test=st.text(),
+    )
+    def test_exclusion_regex_excludes_correct_values(
+        self, exclusion: str | list[str], test: str
+    ):
+        excl_list = list(itx.always_iterable(exclusion))
+        assume(test not in excl_list)
+
+        pf = PostFilter()
+        pf.add_filter("", None, exclusion)
+        pattern = pf.exclusions[""][0]
+        # normalize exclusion into a list for testing
+        # should not match excluded values
+        for ex in excl_list:
+            assert re.match(pattern, ex) is None
+        # should match other values
+        assert re.match(pattern, "".join(excl_list) + "_") is not None
+        assert re.match(pattern, "_" + "".join(excl_list)) is not None
+        assert re.match(pattern, test) is not None
+
+    @given(key=st.text())
+    def test_add_filter_overwrites_duplicate_keys(self, key: str):
+        pf = PostFilter()
+        pf.add_filter(key, "a", None)
+        assert pf.inclusions[key] == ["a"]
+        pf.add_filter(key, "b", None)
+        assert pf.inclusions[key] == ["b"]
+
+    def test_multiple_filters_in_postfilter(self):
+        pf = PostFilter()
+        pf.add_filter("subject", "a", None)
+        pf.add_filter("session", None, "s1")
+        assert "subject" in pf.inclusions
+
+        assert "session" in pf.exclusions
+
+
+class TestUnifiedFilter:
+    @pytest.mark.parametrize("attr", ["prefilters", "get"])
+    @given(comp=sb_st.input_configs(wildcards=False, paths=False))
+    def test_regex_search_removed_from_prefilters(self, comp: InputConfig, attr: str):
+        # ensure regex_search present in component filters
+        filters = dict(comp.get("filters", {}), regex_search=True)
+        comp["filters"] = filters
+        uf = UnifiedFilter(component=comp, postfilters=PostFilter())
+        compiled = getattr(uf, attr)
+
+        assert "regex_search" in filters
+        assert "regex_search" not in compiled
+        # other filters should be preserved (presence for .get, exact for .prefilters)
+        filters.pop("regex_search")
+        if attr == "prefilters":
+            assert compiled == filters
+        else:
+            assert set(compiled) == set(filters)
+
+    @pytest.mark.parametrize("inclusion", [True, False])
+    @given(filters=_filters())
+    def test_postfilters_incorporated_into_unified_filter(
+        self, filters: dict[str, str], inclusion: bool
+    ):
+        pf = PostFilter()
+        for k, v in filters.items():
+            if inclusion:
+                pf.add_filter(k, v, None)
+            else:
+                pf.add_filter(k, None, v)
+        dummy = "".join(filters.keys()) + "_"
+        uf = UnifiedFilter(
+            component={
+                "filters": {dummy: ""},
+                "wildcards": list(filters.keys()),
+            },
+            postfilters=pf,
+        )
+        if inclusion:
+            assert set(uf.get) == set(filters) | {dummy}
+        else:
+            assert set(uf.post_exclusions) == set(filters)
+
+    def test_empty_postfilter_inclusion_turned_into_pybids_query(self):
+        # An empty inclusion postfilter should be turned into Query.ANY in uf.get
+        pf = PostFilter()
+        pf.add_filter("", [], None)
+
+        # component should list the entity as a wildcard so postfilter applies
+        uf = UnifiedFilter(
+            component={"wildcards": [""]},
+            postfilters=pf,
+        )
+
+        assert uf.get[""][0] is Query.ANY
+
+    @pytest.mark.parametrize("inclusion", [True, False])
+    @given(filters=_filters(min_size=2))
+    def test_postfilters_skipped_when_not_wildcards(
+        self, filters: dict[str, str], inclusion: bool
+    ):
+        pf = PostFilter()
+        for k, v in filters.items():
+            if inclusion:
+                pf.add_filter(k, v, None)
+            else:
+                pf.add_filter(k, None, v)
+        filters.popitem()
+        # All but withdrawn entity in wildcards
+        uf = UnifiedFilter(component={"wildcards": list(filters)}, postfilters=pf)
+        assert set(filters) == set(uf.get if inclusion else uf.post_exclusions)
+
+    @pytest.mark.parametrize("inclusion", [True, False])
+    @given(filters=_filters(min_size=2))
+    def test_post_exclusions_skips_entities_that_are_filters(
+        self, filters: dict[str, str], inclusion: bool
+    ):
+        pf = PostFilter()
+        for k, v in filters.items():
+            if inclusion:
+                pf.add_filter(k, v, None)
+            else:
+                pf.add_filter(k, None, v)
+        wildcards = list(filters)
+        entity, value = filters.popitem()
+        uf = UnifiedFilter(
+            component={"wildcards": wildcards, "filters": {entity: value * 2}},
+            postfilters=pf,
+        )
+        # since entity is present in prefilters, it should be skipped
+        if inclusion:
+            assert uf.get[entity] == [value * 2]
+        else:
+            assert entity not in uf.post_exclusions
+
+    @pytest.mark.parametrize("attr", ["get", "search"])
+    @given(filters=_mixed_filters)
+    def test_get_and_search_return_appropriate_methods(
+        self,
+        filters: dict[str, str | list[str] | dict[str, None]],
+        attr: str,
+    ):
+        # Build UnifiedFilter from the mixed filters and check that `get` only
+        # contains 'get' (including simple string/list forms) and `search` only
+        # contains 'match'/'search' filters.
+        uf = UnifiedFilter.from_filter_dict(filters)  # type: ignore[arg-type]
+        compiled = getattr(uf, attr)
+
+        for key, raw in filters.items():
+            method = next(iter(raw.keys())) if isinstance(raw, dict) else "get"
+
+            if attr == "get":
+                expected = method == "get"
+            else:
+                expected = method in ("match", "search")
+
+            assert (key in compiled) == expected
+
+    @pytest.mark.parametrize("empty_list", [True, False])
+    @given(
+        filters=st.dictionaries(
+            sb_st.bids_entity().map(str), st.text() | st.lists(st.text(), min_size=1)
+        )
+    )
+    def test_has_empty_prefilter_detects_empty_list(
+        self, filters: dict[str, str | list[str]], empty_list: bool
+    ):
+        if empty_list:
+            filters["".join(filters)] = []
+        uf = UnifiedFilter.from_filter_dict(filters)
+        assert uf.has_empty_prefilter == empty_list
+
+    @pytest.mark.parametrize("empty_list", [True, False])
+    @given(
+        filters=st.dictionaries(
+            sb_st.bids_entity().map(str), st.text() | st.lists(st.text(), min_size=1)
+        )
+    )
+    def test_has_empty_postfilter_detects_empty_list(
+        self, filters: dict[str, str | list[str]], empty_list: bool
+    ):
+        pf = PostFilter()
+        for k, v in filters.items():
+            pf.add_filter(k, v, None)
+        dummy = "".join(filters)
+        if empty_list:
+            pf.add_filter(dummy, [], None)
+        uf = UnifiedFilter(component={"wildcards": [*filters, dummy]}, postfilters=pf)
+        assert uf.has_empty_postfilter == empty_list
+
+    # without_bools behavior tested below with parameterized cases
+    @given(
+        value=st.booleans()
+        | st.lists(st.booleans(), min_size=1)
+        | st.tuples(st.booleans(), st.text()).map(list)
+    )
+    def test_without_bools_raises_when_bools_present(self, value: bool):
+        """Accessing without_bools must raise when boolean filters are present."""
+        uf = UnifiedFilter.from_filter_dict({"": value})
+        with pytest.raises(
+            ValueError,
+            match=("Boolean filters in items with custom paths are not supported"),
+        ):
+            _ = uf.without_bools
+
+    @given(value=st.text() | st.lists(st.text()))
+    def test_without_bools_returns_when_no_bools(self, value: str | list[str]):
+        """without_bools should return the mapping when no boolean filters exist."""
+        uf = UnifiedFilter.from_filter_dict({"": value})
+        result = uf.without_bools
+        assert "" in result
+
+
+class TestCompileFilters:
+    @pytest.mark.parametrize(
+        ("method_a", "method_b"),
+        list(it.combinations(sorted(_VALID_FILTER_METHODS), 2)),
+    )
+    def test_multiple_filtering_methods_raises_error(
+        self, method_a: str, method_b: str
+    ):
+        # dict with two different filtering methods should raise a _TooManyKeysError
+        filt = {method_a: "_", method_b: "_"}
+        with pytest.raises(_TooManyKeysError):
+            _compile_filters({"": filt}, with_regex=False)  # type: ignore[arg-type]
+
+    def test_dict_with_no_filtering_methods_raises_error(self):
+        # empty dict as a filter value should raise a _TooFewKeysError
+        with pytest.raises(_TooFewKeysError):
+            _compile_filters({"": {}}, with_regex=False)  # type: ignore[arg-type]
+
+    @given(method=st.text().filter(lambda t: t not in _VALID_FILTER_METHODS))
+    def test_invalid_filtering_method_raises_error(self, method: str):
+        # unknown filtering key should raise a _InvalidKeyError
+        with pytest.raises(_InvalidKeyError):
+            _compile_filters({"": {method: ""}}, with_regex=False)  # type: ignore[arg-type]
+
+    @given(entity=sb_st.bids_entity().map(str), val=st.text())
+    def test_string_filter_wrapped_with_list(self, entity: str, val: str):
+        # plain string filters should be wrapped into a single-element list
+        res = _compile_filters({entity: val}, with_regex=False)
+        assert isinstance(res, dict)
+        assert entity in res
+        assert isinstance(res[entity], list)
+        assert res[entity][0] == val
+
+    @pytest.mark.parametrize(
+        ("kind", "with_regex"),
+        [
+            ("simple", False),
+            ("list", False),
+            ("get", False),
+            ("match", True),
+            ("search", True),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("val", "expected"),
+        [
+            (True, Query.ANY),
+            (False, Query.NONE),
+        ],
+    )
+    @given(entity=sb_st.bids_entity().map(str))
+    def test_boolean_filters_converted_to_pybids_queries(
+        self, entity: str, kind: str, with_regex: bool, val: bool, expected: object
+    ):
+        """Boolean filters (True/False) should convert to Query.ANY / Query.NONE
+
+        Test three shapes for each boolean: simple boolean, boolean in a list, and
+        boolean nested under each of the valid methods ('get','match','search').
+        """
+        if kind == "simple":
+            filt = {entity: val}
+        elif kind == "list":
+            filt = {entity: [val]}
+        else:
+            filt = {entity: {kind: val}}
+        res = _compile_filters(filt, with_regex=with_regex)  # type: ignore[arg-type]
+        assert res[entity][0] is expected
+
+    @given(txt=st.text())
+    def test_match_filters_converted_to_valid_regex(self, txt: str):
+        # match should produce anchored regex that matches exactly
+        res = _compile_filters({"": {"match": re.escape(txt)}}, with_regex=True)
+        pattern = cast(str, res[""][0])
+        assert re.match(pattern, txt) is not None
+        assert re.match(pattern, txt + "_") is None
+
+    @pytest.mark.parametrize("method", ["match", "search"])
+    @given(txt=st.text(alphabet=string.ascii_lowercase, min_size=1))
+    def test_regex_filters_case_sensitive(self, method: str, txt: str):
+        res = _compile_filters({"": {method: txt}}, with_regex=True)  # pyright: ignore[reportArgumentType]
+        pattern = cast(str, res[""][0])
+        assert getattr(re, method)(pattern, txt.upper()) is None
+
+    @given(txt=st.text())
+    def test_search_filters_converted_to_valid_regex(self, txt: str):
+        # search should produce regex that matches when substring present
+        res = _compile_filters({"": {"search": re.escape(txt)}}, with_regex=True)
+        pattern = cast(str, res[""][0])
+        assert re.search(pattern, "_" + txt + "_") is not None
+
+    @given(txt=st.text(min_size=2).filter(lambda t: t != t[::-1]))
+    def test_search_filters_only_match_query(self, txt: str):
+        # search should produce regex that matches when substring present
+        res = _compile_filters({"": {"search": re.escape(txt)}}, with_regex=True)
+        pattern = cast(str, res[""][0])
+        assert re.search(pattern, txt[::-1]) is None
+
+    @given(txt=st.text())
+    def test_get_filters_stay_as_str(self, txt: str):
+        # explicit get method should leave the string as-is
+        res = _compile_filters({"": {"get": txt}}, with_regex=False)
+        assert cast(str, res[""][0]) == txt
+
+    @pytest.mark.parametrize(
+        ("method", "with_regex"),
+        [
+            ("get", True),
+            ("match", False),
+            ("search", False),
+            (None, True),
+        ],
+    )
+    @given(entity=sb_st.bids_entity().map(str))
+    def test_filter_skipped_when_with_regex_not_matching(
+        self, entity: str, method: str | None, with_regex: bool
+    ):
+        filt = {entity: ""} if method is None else {entity: {method: ""}}
+
+        res = _compile_filters(filt, with_regex=with_regex)  # type: ignore[arg-type]
+
+        assert entity not in res
+
+
+class _FakeBIDSLayout:
+    def __init__(self, get: list[str] | None = None, search: list[str] | None = None):
+        self.get_called = False
+        self.search_called = False
+        self.get_return = get or []
+        self.search_return = search or []
+
+    def get(self, regex_search: bool, **filters: Sequence[str]):
+        query = re.search(
+            filters.popitem()[1][0] if filters else "get", "searchgeterror"
+        )
+        assert query
+        query = query[0]
+        if query == "error":
+            raise AttributeError
+        assert regex_search == (query == "search")
+        if query == "search":
+            self.search_called = True
+            return self.search_return
+        assert query == "get"
+        self.get_called = True
+        return self.get_return
+
+
+class TestGetMatchingFiles:
+    def _create_unified_filter(self, *, get: bool, search: bool, error: bool):
+        """Create a small UnifiedFilter for tests.
+
+        Arguments are keyword-only to make call sites explicit about intent.
+        """
+        filter_dict: FilterMap = {}
+        if get:
+            filter_dict["get"] = "error" if error else "get"
+        if search:
+            filter_dict["search"] = {"search": "error" if error else "search"}
+        return UnifiedFilter.from_filter_dict(filter_dict)
+
+    @pytest.mark.parametrize("get", [False, True])
+    @pytest.mark.parametrize("search", [False, True])
+    def test_get_and_search_called_correctly(self, get: bool, search: bool):
+        """Test appropriate call of BIDSLayout.get.
+
+        When called with filters from UnifiedFilter.get, regex_search should be False. A
+        call with regex_search == False should be made every time.
+
+        When called with filters from UnifiedFilter.search, regex_search should be True.
+        A call with regex_search == True should only be made when UnifiedFilter.search
+        returns a Filter.
+        """
+        layout = _FakeBIDSLayout()
+        filters = self._create_unified_filter(get=get, search=search, error=False)
+        get_matching_files(layout, filters)  # pyright: ignore[reportArgumentType]
+        assert layout.get_called
+        assert layout.search_called == search
+
+    @pytest.mark.parametrize(("get", "search"), [(True, False), (False, True)])
+    def test_get_and_search_catches_attribute_error(self, get: bool, search: bool):
+        layout = _FakeBIDSLayout()
+        filters = self._create_unified_filter(get=get, search=search, error=True)
+        with pytest.raises(
+            PybidsError,
+            match="Pybids has encountered a problem that Snakebids cannot handle. ",
+        ):
+            get_matching_files(layout, filters)  # pyright: ignore[reportArgumentType]
+
+    @given(get=st.sets(st.text()), search=st.sets(st.text()))
+    def test_returns_intersection_of_get_and_search(
+        self, get: set[str], search: set[str]
+    ):
+        files = get_matching_files(
+            _FakeBIDSLayout(get, search),  # pyright: ignore[reportArgumentType]
+            self._create_unified_filter(get=True, search=True, error=False),
+        )
+        assert set(files) == get & search
+
+    def test_preserves_order_of_files(self):
+        get = list(map(str, range(1000)))
+        search = list(map(str, range(1000)[::2]))
+        layout = _FakeBIDSLayout(get, search)
+        filters = self._create_unified_filter(get=True, search=True, error=False)
+        files = get_matching_files(layout, filters)  # pyright: ignore[reportArgumentType]
+        assert files == search


### PR DESCRIPTION
Continuation of #474. 

This PR primarily refactors the filtering tests for `generate_input()`. The previous tests used hypothesis to generate components, wrote them as datasets to the filesystem, and reindexed them with pybids and various combinations of filters. These calls were expensive and time consuming, and prone to hypothesis flaky errors.

The new suite breaks down the tests into focused, hypothesis-based unit tests that do not read and write to the fs. The old tests are reused as integration tests, but using a few strategic parametrize examples instead of hypothesis. 

A few minor optimizations are also made in the filtering code.

Aside: Previously had explicitly specified uv as the executor for poe. This was making the linter angry (for some reason), and is not actually necessary, because poe autodetects the uv.lock file. So I removed the setting