### PR TITLE
fix: raise error for lone closing braces in SnakemakeFormatter

### DIFF
--- a/tests/test_paths/test_bids.py
+++ b/tests/test_paths/test_bids.py
@@ -376,7 +376,10 @@ def make_bids_testsuite(spec: BidsPathSpec):
             template = bids(
                 root="",
                 **(
-                    {k: v.replace("{", "{{") for k, v in mandatory.items()}
+                    {
+                        k: v.replace("{", "{{").replace("}", "}}")
+                        for k, v in mandatory.items()
+                    }
                     | dict.fromkeys(optional, OPTIONAL_WILDCARD)
                 ),
             )

--- a/tests/test_paths/test_bids.py
+++ b/tests/test_paths/test_bids.py
@@ -19,7 +19,7 @@ from snakebids.snakemake_compat import regex_from_filepattern
 from snakebids.utils.snakemake_templates import SnakemakeFormatter
 from snakebids.utils.utils import BidsEntity
 from tests import strategies as sb_st
-from tests.helpers import Benchmark, debug, is_strictly_increasing
+from tests.helpers import Benchmark, is_strictly_increasing
 from tests.test_snakemake_templates.strategies import safe_field_names
 
 
@@ -385,7 +385,6 @@ def make_bids_testsuite(spec: BidsPathSpec):
 
             assert formatter.format(template, **args) == reference
 
-        @debug(mandatory={"prefix": "0"}, optional={"A": "0", "extension": ".0"})
         @given(
             mandatory=_bids_args(
                 use_wildcard_only=True, custom=_identifiers(), prefix=True

--- a/tests/test_snakemake_templates/strategies.py
+++ b/tests/test_snakemake_templates/strategies.py
@@ -43,5 +43,5 @@ def constraints(*, exclude_characters: Collection[str] | None = None):
 
 def literals(*, exclude_characters: Collection[str] | None = None):
     return st.text(st.characters(exclude_characters=exclude_characters)).map(
-        lambda s: s.replace("{", "{{")
+        lambda s: s.replace("{", "{{").replace("}", "}}")
     )


### PR DESCRIPTION
Previously, `SnakemakeFormatter.parse()` silently ignored lone `}` characters outside of fields. This diverged from the behavior of Python's `string.Formatter` and could mask typos or malformed templates.

## Changes

- `SnakemakeFormatter.parse()` now raises `ValueError("unexpected '}' in string")` when a lone `}` is encountered outside a field, matching standard formatter behavior.
- Refactored the parse loop to scan for both `{` and `}` simultaneously (tracking the next expected closing brace alongside the next opening brace), eliminating the need for an inner `find("}")` on each field.
- Added tests for lone `}` error cases and fixed the property-based test to no longer strip `}` from generated literal strings.